### PR TITLE
chore: handle if source is playlist m3u8

### DIFF
--- a/demo.ts
+++ b/demo.ts
@@ -2,12 +2,12 @@ import { IRecorderOptions } from "./index.js";
 import { HLSRecorder, ISegments } from "./index";
 
 const rec_opts: IRecorderOptions = {
-  recordDuration: 120,
+  recordDuration: -1,
   windowSize: -1,
   vod: true,
 };
 
-const URI = "http://localhost:8000/channels/1/master.m3u8";
+const URI = "https://cph-p2p-msl.akamaized.net/hls/live/2000341/test/level_0.m3u8";
 // With PROGRAM-DATE-TIME live live
 const URI2 =
   "https://cbsn-us.cbsnstream.cbsnews.com/out/v1/55a8648e8f134e82a470f83d562deeca/master.m3u8";
@@ -20,7 +20,7 @@ const URI4 =
 // With MAP vod all m4s
 const URI5 = "https://bitdash-a.akamaihd.net/content/MI201109210084_1/m3u8s-fmp4/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8"
 
-const recorder = new HLSRecorder(URI5, rec_opts);
+const recorder = new HLSRecorder(URI, rec_opts);
 
 recorder.on(
   "mseq-increment",
@@ -28,26 +28,12 @@ recorder.on(
     const varaints = Object.keys(data.allPlaylistSegments["video"]);
     const level0 = varaints[0];
     console.log(
-      `We got something: ${JSON.stringify(
+      `Recorded Segments: ${JSON.stringify(
         data.allPlaylistSegments["video"][level0],
         null,
         2
       )}`
     );
-    const groups = Object.keys(data.allPlaylistSegments["audio"]);
-    if (groups.length > 0) {
-      const languages = Object.keys(
-        data.allPlaylistSegments["audio"][groups[0]]
-      );
-      const lang0 = languages[0];
-      console.log(
-        `We got some sound: ${JSON.stringify(
-          data.allPlaylistSegments["audio"][groups[0]][lang0],
-          null,
-          2
-        )}`
-      );
-    }
   }
 );
 recorder.on("error", (err: any) => {
@@ -57,7 +43,7 @@ recorder.on("error", (err: any) => {
 
 const run = async () => {
   recorder.start();
-  recorder.listen(1377);
+  recorder.listen(1377); // Playback at "http://localhost:1377/live/master.m3u8"
 };
 /**********************
  * Run Driver function

--- a/util/handlers.ts
+++ b/util/handlers.ts
@@ -21,6 +21,9 @@ export async function _handleMasterManifest(
   masterM3u: string
 ) {
   try {
+    if (masterM3u === "") {
+      masterM3u = "Source HLS steam does not have a multivariant manifest";
+    }
     const body = masterM3u;
     res.sendRaw(200, Buffer.from(body, "utf8"), {
       "Content-Type": "application/x-mpegURL;charset=UTF-8",


### PR DESCRIPTION
To support cases where hls stream only consists of a playlist manifest.