### PR TITLE
fix: bug where all source segs are always pushed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 test-server.ts
 todo.md
 demo.ts
+dev-files

--- a/index.ts
+++ b/index.ts
@@ -656,7 +656,7 @@ export class HLSRecorder extends EventEmitter {
           }
         } else {
           // Compare by mseq counts and segment amount
-          if (this.segments["video"][bw] && this.segments["video"][bw].mediaSeq) {
+          if (this.segments["video"][bw] && this.segments["video"][bw].mediaSeq !== undefined) {
             const segCountDiff = this.currSourceSegCount - this.prevSourceSegCount;
             const mseqDiff = sourceMediaSeq - this.segments["video"][bw].mediaSeq;
             let pushAmount;
@@ -759,7 +759,7 @@ export class HLSRecorder extends EventEmitter {
           if (
             this.segments["audio"][audioGroup] &&
             this.segments["audio"][audioGroup][audioLanguage] &&
-            this.segments["audio"][audioGroup][audioLanguage].mediaSeq
+            this.segments["audio"][audioGroup][audioLanguage].mediaSeq !== undefined
           ) {
             const segCountDiff = sourceSegCount - this.prevSourceSegCount;
             const mseqDiff =
@@ -850,7 +850,7 @@ export class HLSRecorder extends EventEmitter {
           if (
             this.segments["subtitle"][subtitleGroup] &&
             this.segments["subtitle"][subtitleGroup][subtitleLanguage] &&
-            this.segments["subtitle"][subtitleGroup][subtitleLanguage].mediaSeq
+            this.segments["subtitle"][subtitleGroup][subtitleLanguage].mediaSeq !== undefined
           ) {
             const segCountDiff = sourceSegCount - this.prevSourceSegCount;
             const mseqDiff =


### PR DESCRIPTION
This PR fixes #30 

It should now handle live HLS streams that ever have 0 as a Media Sequence value in its media playlists manifests