### PR TITLE
test: add unit tests

### DIFF
--- a/demo.ts
+++ b/demo.ts
@@ -30,8 +30,8 @@ const recorder = new HLSRecorder(URI2, rec_opts);
 recorder.on(
   "mseq-increment",
   async (data: { allPlaylistSegments: ISegments }) => {
-    const varaints = Object.keys(data.allPlaylistSegments["video"]);
-    const level0 = varaints[0];
+    const variants = Object.keys(data.allPlaylistSegments["video"]);
+    const level0 = variants[0];
     console.log(
       `Recorded Segments: ${JSON.stringify(
         data.allPlaylistSegments["video"][level0],

--- a/index.ts
+++ b/index.ts
@@ -121,6 +121,11 @@ export enum PlaylistType {
   LIVE = 2,
   EVENT = 3,
 }
+export interface IMseqIncrementEventPayload {
+  allPlaylistSegments: ISegments;
+  type: PlaylistType;
+  cookieJar: CookieJar;
+}
 
 const FAIL_TIMEOUT: number = 3000;
 const DEFAULT_MAX_WINDOW_SIZE: number = 5 * 60;
@@ -1362,7 +1367,7 @@ export class HLSRecorder extends EventEmitter {
         // Decrement fetch counter
         FETCH_ATTEMPTS--;
         // Wait a little before trying again
-        debug(`[ALERT! Live Source Data NOT in sync! Will try again after 1500ms`);
+        debug(`ALERT! Live Source Data NOT in sync! Will try again after 1500ms`);
         await this._timer(1500);
         this.timerCompensation = false; // TODO: implement this right
         continue;

--- a/index.ts
+++ b/index.ts
@@ -24,8 +24,6 @@ import {
   IRecData,
 } from "./util/handlers.js";
 
-const timer = (ms: number) => new Promise((res) => setTimeout(res, ms));
-
 export interface IRecorderOptions {
   recordDuration?: number; // how long in seconds before ending event-stream
   windowSize?: number; // sliding window size
@@ -292,7 +290,7 @@ export class HLSRecorder extends EventEmitter {
       try {
         if (this.engine) {
           this.engine.start();
-          await timer(3000);
+          await this._timer(3000);
         }
         // Try to require manifest at set interval
         await this.startPlayhead();
@@ -417,14 +415,14 @@ export class HLSRecorder extends EventEmitter {
           continue;
         }
 
-        // Set the timer
+        // Set the this._timer
         let tickInterval = 0;
         tickInterval = segmentDurationMs - (tsIncrementEnd - tsIncrementBegin);
         tickInterval = tickInterval < 2 ? 2 : tickInterval;
 
         debug(`Playhead going to ping again after ${tickInterval}ms`);
 
-        await timer(tickInterval);
+        await this._timer(tickInterval);
       } catch (err) {
         debug(`Playhead consumer crashed`);
         console.error(err);
@@ -1345,7 +1343,7 @@ export class HLSRecorder extends EventEmitter {
           `ALERT! Promises I: Failed, Rejection Found! Trying again...(tries left=${FETCH_ATTEMPTS})`
         );
         FETCH_ATTEMPTS--;
-        await timer(1500);
+        await this._timer(1500);
         continue;
       }
 
@@ -1365,7 +1363,7 @@ export class HLSRecorder extends EventEmitter {
         FETCH_ATTEMPTS--;
         // Wait a little before trying again
         debug(`[ALERT! Live Source Data NOT in sync! Will try again after 1500ms`);
-        await timer(1500);
+        await this._timer(1500);
         this.timerCompensation = false; // TODO: implement this right
         continue;
       }
@@ -1534,5 +1532,9 @@ export class HLSRecorder extends EventEmitter {
       });
     }
     return totalDurationInSeconds;
+  }
+
+  _timer(ms: number): Promise<void> {
+    return new Promise((res) => setTimeout(res, ms));
   }
 }

--- a/index.ts
+++ b/index.ts
@@ -162,12 +162,11 @@ export class HLSRecorder extends EventEmitter {
   sourceAudioManifestURIs: any;
   server: any;
 
-  engine: any; // todo channel engine type defs
+  engine: any; // TODO: use channel engine type defs
   cookieJar: CookieJar;
   serverStartTime: number;
   discontinuitySequence: any;
   serverStarted: boolean;
-  timerCompensation: boolean | undefined;
   shouldEmitt: boolean | null;
   currSourceSegCount: number;
 
@@ -331,7 +330,7 @@ export class HLSRecorder extends EventEmitter {
         resolve("Success");
       } catch (err) {
         this.emit("error", err);
-        reject("Something went wrong stoping the recorder!: " + JSON.stringify(err));
+        reject("Something went wrong when stopping the recorder!: " + JSON.stringify(err));
       }
     });
   }
@@ -366,7 +365,7 @@ export class HLSRecorder extends EventEmitter {
           debug(`Playhead Stopped!`);
           return;
         }
-        // Let the playhead move at an interval set according to top segment duration
+        // Let the playhead move at an interval set according to newest segment duration
         let segmentDurationMs: any = 6000;
         let videoBws = Object.keys(this.segments["video"]);
         let segmentCount = this.segments["video"][videoBws[0]].segList.length;
@@ -378,12 +377,11 @@ export class HLSRecorder extends EventEmitter {
           }
         }
 
-        // Fetch Source Segments, and get ready manifest generation
-        // And also compensate for processing time
+        // Fetch Source Manifests
         const tsIncrementBegin = Date.now();
         await this._loadAllManifest();
         const tsIncrementEnd = Date.now();
-        // Is the Event over Case 1
+        // Is the Event over? Case 1
         if (this.sourcePlaylistType === PlaylistType.VOD) {
           debug(
             "Source has become a VOD. And vodRealTime Config is false.",
@@ -397,7 +395,7 @@ export class HLSRecorder extends EventEmitter {
           this.stopPlayhead();
           continue;
         }
-        // Is the Event over Case 2?
+        // Is the Event over? Case 2
         if (
           this.targetRecordDuration !== -1 &&
           this.currentRecordDuration >= this.targetRecordDuration
@@ -420,7 +418,7 @@ export class HLSRecorder extends EventEmitter {
           continue;
         }
 
-        // Set the this._timer
+        // Set the timer
         let tickInterval = 0;
         tickInterval = segmentDurationMs - (tsIncrementEnd - tsIncrementBegin);
         tickInterval = tickInterval < 2 ? 2 : tickInterval;
@@ -524,7 +522,7 @@ export class HLSRecorder extends EventEmitter {
   }
 
   async _getEngineManifests(): Promise<void> {
-    const channelId = "1"; // Read from options maybe?
+    const channelId = "1"; // (Read from options maybe?)
     try {
       if (this.sourceMasterManifest === "") {
         this.sourceMasterManifest = await this.engine.getMasterManifest(channelId);
@@ -539,9 +537,7 @@ export class HLSRecorder extends EventEmitter {
   }
 
   async _getLiveManifests(): Promise<void> {
-    // Try to set Live URI
     try {
-      // Rewrite Playlist URL in Master
       if (this.sourceMasterManifest === "") {
         debug(`Going to fetch Live Master Manifest!`);
         // Load & Parse all Media Manifest URIs from Master. Set value in sourceMasterManifest
@@ -550,7 +546,6 @@ export class HLSRecorder extends EventEmitter {
         if (parserData.masterM3U === -1) {
           this.masterManifest = "";
         } else {
-          // Replace with m3u8 gen
           this.masterManifest = await GenerateMasterM3U8(parserData.masterM3U);
         }
       }
@@ -566,14 +561,12 @@ export class HLSRecorder extends EventEmitter {
   // -= M3U8 Load & Parser Functions =-
   async _loadM3u8Segments(): Promise<void> {
     let loadPromises: Promise<void>[] = [];
-
     // For each bandwidth...
     const bandwidths = Object.keys(this.mediaManifests);
     bandwidths.forEach((bw) => {
       loadPromises.push(this._loadMediaSegments(parseInt(bw)));
     });
-
-    // For each group...
+    // For each audio group...
     const audioGroups = Object.keys(this.audioManifests);
     audioGroups.forEach((group) => {
       const audioLangs = Object.keys(this.audioManifests[group]);
@@ -583,8 +576,7 @@ export class HLSRecorder extends EventEmitter {
         loadPromises.push(this._loadAudioSegments(group, lang));
       }
     });
-
-    // For each group...
+    // For each subtitle group...
     const subtitleGroups = Object.keys(this.subtitleManifests);
     subtitleGroups.forEach((group) => {
       const subtitleLangs = Object.keys(this.subtitleManifests[group]);
@@ -594,7 +586,6 @@ export class HLSRecorder extends EventEmitter {
         loadPromises.push(this._loadSubtitleSegments(group, lang));
       }
     });
-
     await Promise.all(loadPromises);
     // Post-loading: Window Size
     if (this.targetWindowSize !== -1) {
@@ -628,12 +619,6 @@ export class HLSRecorder extends EventEmitter {
     debug(`Segment loading successful!`);
   }
 
-  /**
-   * This function should be able to handle parsing media manifest
-   * from live streams that may or may not have tags other than (duration, uri)
-   * @param bw
-   * @returns
-   */
   async _loadMediaSegments(bw: number): Promise<void> {
     const parser = m3u8.createStream();
     let m3uString = this.mediaManifests[bw];
@@ -780,7 +765,6 @@ export class HLSRecorder extends EventEmitter {
             this.segments["audio"][audioGroup][audioLanguage].mediaSeq = sourceMediaSeq;
           }
         }
-
         // For each 'new' playlist item...
         for (let i = startIdx; i < m3u.items.PlaylistItem.length; i++) {
           const playlistItem = m3u.items.PlaylistItem[i];
@@ -794,12 +778,10 @@ export class HLSRecorder extends EventEmitter {
               segList: [],
             };
           }
-
           // Get Next Segment Index Number
           let segIdx: number | null = this._getNextSegmentIndex(
             this.segments["audio"][audioGroup][audioLanguage].segList
           );
-
           // Build Segment Item
           let audioSegment;
           if (this.livePlaylistUris) {
@@ -871,11 +853,8 @@ export class HLSRecorder extends EventEmitter {
             this.segments["subtitle"][subtitleGroup][subtitleLanguage].mediaSeq = sourceMediaSeq;
           }
         }
-
-        // For each 'new' playlist item...
         for (let i = startIdx; i < m3u.items.PlaylistItem.length; i++) {
           const playlistItem = m3u.items.PlaylistItem[i];
-          // Init first time.
           if (!this.segments["subtitle"][subtitleGroup]) {
             this.segments["subtitle"][subtitleGroup] = {};
           }
@@ -885,12 +864,10 @@ export class HLSRecorder extends EventEmitter {
               segList: [],
             };
           }
-
           // Get Next Segment Index Number
           let segIdx: number | null = this._getNextSegmentIndex(
             this.segments["subtitle"][subtitleGroup][subtitleLanguage].segList
           );
-
           // Build Segment Item
           let subtitleSegment;
           if (this.livePlaylistUris) {
@@ -899,7 +876,6 @@ export class HLSRecorder extends EventEmitter {
           } else {
             subtitleSegment = this._playlistItemToSegment(playlistItem, segIdx);
           }
-
           // Push New Segment Item
           this.segments["subtitle"][subtitleGroup][subtitleLanguage].segList.push(subtitleSegment);
           // Allow for event to be emitted when done
@@ -956,7 +932,6 @@ export class HLSRecorder extends EventEmitter {
             formatVersions: typeof keyFormatVersions !== "undefined" ? keyFormatVersions : null,
           }
         : null;
-    // Use Absolute Path
     if (key?.uri) {
       if (!key?.uri.match("^http")) {
         if (baseUrl) {
@@ -975,7 +950,6 @@ export class HLSRecorder extends EventEmitter {
             byterange: typeof mapByterange !== "undefined" ? mapByterange : null,
           }
         : null;
-    // Use Absolute Path
     if (map?.uri) {
       if (!map?.uri.match("^http")) {
         if (baseUrl) {
@@ -1051,7 +1025,6 @@ export class HLSRecorder extends EventEmitter {
           this.segments["audio"][group][lang].segList.push(finalSegment);
         }
       });
-
       // Add tag for all subtitle
       const groupsSubs = Object.keys(this.segments["subtitle"]);
       groupsSubs.forEach((group) => {
@@ -1061,7 +1034,6 @@ export class HLSRecorder extends EventEmitter {
           this.segments["subtitle"][group][lang].segList.push(finalSegment);
         }
       });
-
       debug(`Endlist tag! Added to all Media Playlists!`);
     } catch (err) {
       debug(`Error when adding Endlist tag! ${err}`);
@@ -1302,7 +1274,6 @@ export class HLSRecorder extends EventEmitter {
           livePromises.push(this._fetchPlaylistManifest(videoPlaylists[bw]));
           debug(`Pushed promise for fetching bw=[${bw}] from->${videoPlaylists[bw]}`);
         });
-
         // Append promises for fetching all audio playlist
         let audioGroups = Object.keys(audioPlaylists);
         audioGroups.forEach((group) => {
@@ -1315,7 +1286,6 @@ export class HLSRecorder extends EventEmitter {
             );
           }
         });
-
         // Append promises for fetching all subtitles playlist
         let subtitleGroups = Object.keys(subtitlePlaylists);
         subtitleGroups.forEach((group) => {
@@ -1328,7 +1298,6 @@ export class HLSRecorder extends EventEmitter {
             );
           }
         });
-
         // Fetch From Live Source
         debug(`Executing Promises I: Fetch From Live Source`);
         resultsList = await allSettled(livePromises);
@@ -1364,15 +1333,11 @@ export class HLSRecorder extends EventEmitter {
         !allMediaSeqCounts.every((val, i, arr) => val === arr[0])
       ) {
         debug(`Live Mseq counts=[${allMediaSeqCounts}]`);
-        // Decrement fetch counter
         FETCH_ATTEMPTS--;
-        // Wait a little before trying again
         debug(`ALERT! Live Source Data NOT in sync! Will try again after 1500ms`);
         await this._timer(1500);
-        this.timerCompensation = false; // TODO: implement this right
         continue;
       }
-
       if (FETCH_ATTEMPTS === 0) {
         debug(`Fetching from Live-Source did not work! Returning to Playhead Loop...`);
         return;
@@ -1380,7 +1345,7 @@ export class HLSRecorder extends EventEmitter {
       debug(
         `Success! Managed to fetch from Live-Source, and all playlists are on the same Media-Sequence_${allMediaSeqCounts[0]}`
       );
-      /* APPEND THE GOOD NEWS TO  */
+
       let valueList = resultsList.map((item) => item.value);
       this.mediaManifests = this._appendToMediaManifests(valueList);
       this.audioManifests = this._appendToAudioManifests(valueList);
@@ -1390,7 +1355,6 @@ export class HLSRecorder extends EventEmitter {
   }
 
   async _fetchPlaylistManifest(playlistUri: string): Promise<FetchResult> {
-    // Get the target media manifest
     const parser = m3u8.createStream();
     const controller = new AbortController();
     const timeout = setTimeout(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@eyevinn/m3u8": "^0.4.4",
         "@types/debug": "^4.1.7",
+        "@types/jasmine": "^3.10.2",
         "@types/node": "^16.11.6",
         "@types/node-fetch": "^3.0.3",
         "@types/promise.allsettled": "^1.0.3",
@@ -18,6 +19,8 @@
         "abort-controller": "^3.0.0",
         "debug": "^4.3.2",
         "events": "^3.3.0",
+        "jasmine": "^3.10.0",
+        "jasmine-ts": "^0.4.0",
         "node-fetch": "^2.6.6",
         "node-fetch-cookies": "^2.0.3",
         "promise.allsettled": "^1.0.5",
@@ -351,6 +354,27 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "peer": true,
+      "dependencies": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@eyevinn/hls-repeat": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@eyevinn/hls-repeat/-/hls-repeat-0.1.6.tgz",
@@ -478,6 +502,30 @@
         "node >=0.6.0"
       ]
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "peer": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "peer": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "peer": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "peer": true
+    },
     "node_modules/@types/bunyan": {
       "version": "1.8.7",
       "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.7.tgz",
@@ -501,6 +549,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/jasmine": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.10.2.tgz",
+      "integrity": "sha512-qs4xjVm4V/XjM6owGm/x6TNmhGl5iKX8dkTdsgdgl9oFnqgzxLepnS7rN9Tdo7kDmnFD/VEqKrW57cGD2odbEg=="
     },
     "node_modules/@types/ms": {
       "version": "0.7.31",
@@ -556,6 +609,27 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -589,7 +663,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -623,6 +696,12 @@
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "peer": true
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -691,8 +770,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "devOptional": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -706,7 +784,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "devOptional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -882,8 +959,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "devOptional": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/convert-source-map": {
       "version": "1.8.0",
@@ -898,6 +974,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -1037,6 +1119,15 @@
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/dtrace-provider": {
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
@@ -1073,8 +1164,7 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -1171,7 +1261,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -1430,8 +1519,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -1451,7 +1539,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -1505,7 +1592,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1731,7 +1817,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "devOptional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1825,7 +1910,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2122,6 +2206,128 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/jasmine": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.10.0.tgz",
+      "integrity": "sha512-2Y42VsC+3CQCTzTwJezOvji4qLORmKIE0kwowWC+934Krn6ZXNQYljiwK5st9V3PVx96BSiDYXSB60VVah3IlQ==",
+      "dependencies": {
+        "glob": "^7.1.6",
+        "jasmine-core": "~3.10.0"
+      },
+      "bin": {
+        "jasmine": "bin/jasmine.js"
+      }
+    },
+    "node_modules/jasmine-core": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.10.1.tgz",
+      "integrity": "sha512-ooZWSDVAdh79Rrj4/nnfklL3NQVra0BcuhcuWoAwwi+znLDoUeH87AFfeX8s+YeYi6xlv5nveRyaA1v7CintfA=="
+    },
+    "node_modules/jasmine-ts": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/jasmine-ts/-/jasmine-ts-0.4.0.tgz",
+      "integrity": "sha512-bIAWJKUwxfuZfGI1ctEbny7+dsyFzsN0eLzOokxh0qIUCofai2WUEKoe3MMllkGEBXJzbEVYr2IyhJBv4j7SBA==",
+      "dependencies": {
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "jasmine-ts": "lib/index.js"
+      },
+      "peerDependencies": {
+        "jasmine": ">=3.4",
+        "ts-node": ">=3.2.0 <=11",
+        "typescript": ">=3.5.2"
+      }
+    },
+    "node_modules/jasmine-ts/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jasmine-ts/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/jasmine-ts/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jasmine-ts/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/jasmine-ts/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/jasmine-ts/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jasmine-ts/node_modules/yargs": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+      "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jasmine-ts/node_modules/yargs-parser": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
+      "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2262,6 +2468,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "peer": true
+    },
     "node_modules/memcache-client": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/memcache-client/-/memcache-client-0.10.1.tgz",
@@ -2323,7 +2535,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "devOptional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2686,7 +2897,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2985,7 +3195,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3349,7 +3558,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -3387,7 +3595,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -3457,6 +3664,47 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
+    "node_modules/ts-node": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
+      "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
+      "peer": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -3496,7 +3744,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
       "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3747,6 +3994,15 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
     }
   },
   "dependencies": {
@@ -3991,6 +4247,21 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "peer": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "peer": true,
+      "requires": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      }
+    },
     "@eyevinn/hls-repeat": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@eyevinn/hls-repeat/-/hls-repeat-0.1.6.tgz",
@@ -4108,6 +4379,30 @@
         }
       }
     },
+    "@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "peer": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "peer": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "peer": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "peer": true
+    },
     "@types/bunyan": {
       "version": "1.8.7",
       "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.7.tgz",
@@ -4131,6 +4426,11 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/jasmine": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.10.2.tgz",
+      "integrity": "sha512-qs4xjVm4V/XjM6owGm/x6TNmhGl5iKX8dkTdsgdgl9oFnqgzxLepnS7rN9Tdo7kDmnFD/VEqKrW57cGD2odbEg=="
     },
     "@types/ms": {
       "version": "0.7.31",
@@ -4182,6 +4482,18 @@
         "event-target-shim": "^5.0.0"
       }
     },
+    "acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "peer": true
+    },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "peer": true
+    },
     "aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -4207,8 +4519,7 @@
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -4233,6 +4544,12 @@
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "peer": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -4289,8 +4606,7 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "devOptional": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -4304,7 +4620,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "devOptional": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4439,8 +4754,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "devOptional": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "convert-source-map": {
       "version": "1.8.0",
@@ -4455,6 +4769,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "peer": true
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -4559,6 +4879,12 @@
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "peer": true
+    },
     "dtrace-provider": {
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
@@ -4591,8 +4917,7 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -4672,8 +4997,7 @@
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -4865,8 +5189,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "function-bind": {
       "version": "1.1.1",
@@ -4882,8 +5205,7 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
       "version": "1.1.1",
@@ -4922,7 +5244,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -5097,7 +5418,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "devOptional": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -5160,8 +5480,7 @@
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-map": {
       "version": "2.0.2",
@@ -5372,6 +5691,95 @@
         "iterate-iterator": "^1.0.1"
       }
     },
+    "jasmine": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.10.0.tgz",
+      "integrity": "sha512-2Y42VsC+3CQCTzTwJezOvji4qLORmKIE0kwowWC+934Krn6ZXNQYljiwK5st9V3PVx96BSiDYXSB60VVah3IlQ==",
+      "requires": {
+        "glob": "^7.1.6",
+        "jasmine-core": "~3.10.0"
+      }
+    },
+    "jasmine-core": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.10.1.tgz",
+      "integrity": "sha512-ooZWSDVAdh79Rrj4/nnfklL3NQVra0BcuhcuWoAwwi+znLDoUeH87AFfeX8s+YeYi6xlv5nveRyaA1v7CintfA=="
+    },
+    "jasmine-ts": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/jasmine-ts/-/jasmine-ts-0.4.0.tgz",
+      "integrity": "sha512-bIAWJKUwxfuZfGI1ctEbny7+dsyFzsN0eLzOokxh0qIUCofai2WUEKoe3MMllkGEBXJzbEVYr2IyhJBv4j7SBA==",
+      "requires": {
+        "yargs": "^17.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+        },
+        "yargs": {
+          "version": "17.3.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+          "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
+          "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA=="
+        }
+      }
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5485,6 +5893,12 @@
         "semver": "^6.0.0"
       }
     },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "peer": true
+    },
     "memcache-client": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/memcache-client/-/memcache-client-0.10.1.tgz",
@@ -5531,7 +5945,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "devOptional": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -5808,8 +6221,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "devOptional": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "3.1.1",
@@ -6024,8 +6436,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "2.0.0",
@@ -6321,7 +6732,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -6350,7 +6760,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -6402,6 +6811,26 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
+    "ts-node": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
+      "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
+      "peer": true,
+      "requires": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "yn": "3.1.1"
+      }
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -6434,8 +6863,7 @@
     "typescript": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
-      "dev": true
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA=="
     },
     "unbox-primitive": {
       "version": "1.0.1",
@@ -6643,6 +7071,12 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "peer": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "promise.allsettled": "^1.0.5",
         "restify": "^8.6.0",
         "string-to-stream": "^3.0.1",
+        "ts-node": "^10.4.0",
         "url": "^0.11.0"
       },
       "devDependencies": {
@@ -358,7 +359,6 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
       "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -367,7 +367,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
       "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-consumer": "0.8.0"
       },
@@ -505,26 +504,22 @@
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-      "peer": true
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg=="
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-      "peer": true
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw=="
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-      "peer": true
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg=="
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-      "peer": true
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA=="
     },
     "node_modules/@types/bunyan": {
       "version": "1.8.7",
@@ -613,7 +608,6 @@
       "version": "8.7.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
       "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -625,7 +619,6 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -700,8 +693,7 @@
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "peer": true
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -978,8 +970,7 @@
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "peer": true
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -1123,7 +1114,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -2471,8 +2461,7 @@
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "peer": true
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "node_modules/memcache-client": {
       "version": "0.10.1",
@@ -3668,7 +3657,6 @@
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
       "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "0.7.0",
         "@tsconfig/node10": "^1.0.7",
@@ -3999,7 +3987,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4250,14 +4237,12 @@
     "@cspotcode/source-map-consumer": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-      "peer": true
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg=="
     },
     "@cspotcode/source-map-support": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
       "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
-      "peer": true,
       "requires": {
         "@cspotcode/source-map-consumer": "0.8.0"
       }
@@ -4382,26 +4367,22 @@
     "@tsconfig/node10": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-      "peer": true
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg=="
     },
     "@tsconfig/node12": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-      "peer": true
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw=="
     },
     "@tsconfig/node14": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-      "peer": true
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg=="
     },
     "@tsconfig/node16": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-      "peer": true
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA=="
     },
     "@types/bunyan": {
       "version": "1.8.7",
@@ -4485,14 +4466,12 @@
     "acorn": {
       "version": "8.7.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-      "peer": true
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
     },
     "acorn-walk": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "peer": true
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
     },
     "aggregate-error": {
       "version": "3.1.0",
@@ -4548,8 +4527,7 @@
     "arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "peer": true
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "argparse": {
       "version": "1.0.10",
@@ -4773,8 +4751,7 @@
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "peer": true
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -4882,8 +4859,7 @@
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "peer": true
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "dtrace-provider": {
       "version": "0.8.8",
@@ -5896,8 +5872,7 @@
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "peer": true
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "memcache-client": {
       "version": "0.10.1",
@@ -6815,7 +6790,6 @@
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
       "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
-      "peer": true,
       "requires": {
         "@cspotcode/source-map-support": "0.7.0",
         "@tsconfig/node10": "^1.0.7",
@@ -7075,8 +7049,7 @@
     "yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "peer": true
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "node dist/demo.js",
     "postversion": "git push && git push --tags",
     "coverage": "nyc npm test && nyc report",
-    "test": "echo \"WARN: no test specified\" && exit 0"
+    "test": "ts-node node_modules/jasmine/bin/jasmine"
   },
   "author": "Eyevinn Technology AB <work@eyevinn.se>",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@eyevinn/m3u8": "^0.4.4",
     "@types/debug": "^4.1.7",
+    "@types/jasmine": "^3.10.2",
     "@types/node": "^16.11.6",
     "@types/node-fetch": "^3.0.3",
     "@types/promise.allsettled": "^1.0.3",
@@ -31,6 +32,8 @@
     "abort-controller": "^3.0.0",
     "debug": "^4.3.2",
     "events": "^3.3.0",
+    "jasmine": "^3.10.0",
+    "jasmine-ts": "^0.4.0",
     "node-fetch": "^2.6.6",
     "node-fetch-cookies": "^2.0.3",
     "promise.allsettled": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "promise.allsettled": "^1.0.5",
     "restify": "^8.6.0",
     "string-to-stream": "^3.0.1",
+    "ts-node": "^10.4.0",
     "url": "^0.11.0"
   }
 }

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -1,0 +1,817 @@
+const nock = require("nock");
+import { exitCode } from "process";
+import { HLSRecorder, ISegments } from "..";
+import { GenerateMediaM3U8 } from "../util/manifest_generator";
+import {
+  MockLiveM3U8Generator,
+  ILiveStreamPlaylistMetadata,
+  EnumStreamType,
+  IMultiVariantOptions,
+} from "./support/MockLiveM3U8Generator";
+
+const mockBaseUri = "https://mock.mock.com/";
+const mockLiveUri = "https://mock.mock.com/live/master.m3u8";
+const tsNow = Date.now();
+const vTracks = [
+  {
+    bandwidth: 500500,
+    width: 640,
+    height: 266,
+    codecs: "avc1.42c00c",
+  },
+  {
+    bandwidth: 700700,
+    width: 1280,
+    height: 534,
+    codecs: "avc1.42c00c",
+  },
+];
+const aTracks = [
+  {
+    groupId: "aac",
+    language: "en",
+    name: "English",
+    default: true,
+  },
+  {
+    groupId: "aac",
+    language: "sv",
+    name: "Svenska",
+    default: false,
+  },
+];
+const sTracks = [
+  {
+    groupId: "cc",
+    language: "en",
+    name: "English",
+    default: false,
+  },
+];
+
+describe("HLSRecorder", () => {
+  beforeEach(() => {
+    jasmine.clock().install();
+  });
+  afterEach(() => {
+    jasmine.clock().uninstall();
+    nock.cleanAll();
+  });
+  // Test 1
+  it("should record Live type HLS stream, and end recording when target duration is reached", async () => {
+    let LAST_RETURNED_EVENT_DATA: any;
+    const mockHLSSource = new MockLiveM3U8Generator();
+    const config: IMultiVariantOptions = {
+      videoTracks: vTracks,
+      audioTracks: [],
+      subtitleTracks: [],
+    };
+    mockHLSSource.setMultiVariant(config);
+    mockHLSSource.setInitPlaylistData({
+      MSEQ: 0,
+      DSEQ: 0,
+      TARGET_DUR: 10, // duration for all segments in playlist
+      START_ON: 0, // top segment in playlist has this index
+      END_ON: 6, // last segement in playlist h as this index
+    });
+    nock(mockBaseUri)
+      .persist()
+      .get("/live/master.m3u8")
+      .reply(200, mockHLSSource.getMultiVariant())
+      .get("/live/level_0.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-500500");
+        mockHLSSource.shiftSegments("video-500500", 1);
+        mockHLSSource.pushSegments("video-500500", 1);
+        return m3u8;
+      })
+      .get("/live/level_1.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-700700");
+        mockHLSSource.shiftSegments("video-700700", 1);
+        mockHLSSource.pushSegments("video-700700", 1);
+        return m3u8;
+      });
+
+    const recorder = new HLSRecorder(mockLiveUri, {
+      recordDuration: 120,
+      windowSize: -1,
+      vod: true,
+    });
+    recorder.on("mseq-increment", async (data: { allPlaylistSegments: ISegments }) => {
+      // const variants = Object.keys(data.allPlaylistSegments["video"]);
+      // const variantData = data.allPlaylistSegments["video"][variants[0]];
+      // console.log(`Recorded Segments: ${JSON.stringify(variantData, null, 2)}`);
+      LAST_RETURNED_EVENT_DATA = data;
+    });
+    recorder.on("error", (err: any) => {
+      throw new Error("Something Bad Happend (>.<)" + err);
+    });
+
+    spyOn(recorder, "_timer").and.callFake(() => Promise.resolve());
+    await recorder.start();
+
+    const variants = Object.keys(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"]);
+    variants.forEach((variant) => {
+      const lastIndex =
+        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList.length - 1;
+      // Check First Segment
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[0].index).toBe(
+        1
+      );
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[0].uri).toBe(
+        `https://mock.mock.com/live/video-${variant}-seg_0.ts`
+      );
+      // Check Second-to-Last Segment
+      expect(
+        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[lastIndex - 1].index
+      ).toBe(12);
+      expect(
+        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[lastIndex - 1].uri
+      ).toBe(`https://mock.mock.com/live/video-${variant}-seg_11.ts`);
+      // Check Last Segment
+      expect(
+        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[lastIndex].index
+      ).toBe(null);
+      expect(
+        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[lastIndex].endlist
+      ).toBe(true);
+      // Bonus
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].mediaSeq).toBe(6); // Six Iterations Since Start...
+    });
+  });
+
+  // Test 2
+  it("should record Event type HLS stream, and end recording when #EXT-X-ENDLIST appears in HLS stream", async () => {
+    let LAST_RETURNED_EVENT_DATA: any;
+    const targetEndlistIndex = 15;
+    const mockHLSSource = new MockLiveM3U8Generator();
+    const config: IMultiVariantOptions = {
+      videoTracks: vTracks,
+      audioTracks: [],
+      subtitleTracks: [],
+    };
+    mockHLSSource.setMultiVariant(config);
+    mockHLSSource.setInitPlaylistData({
+      MSEQ: 0,
+      DSEQ: 0,
+      TARGET_DUR: 10, // duration for all segments in playlist
+      START_ON: 0, // top segment in playlist has this index
+      END_ON: 5, // last segement in playlist h as this index
+    });
+    mockHLSSource.insertAt("\n#EXT-X-ENDLIST", targetEndlistIndex); // will slap on an endlist tag at this seg index
+    nock(mockBaseUri)
+      .persist()
+      .get("/live/master.m3u8")
+      .reply(200, mockHLSSource.getMultiVariant())
+      .get("/live/level_0.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-500500");
+        mockHLSSource.pushSegments("video-500500", 1);
+        return m3u8;
+      })
+      .get("/live/level_1.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-700700");
+        mockHLSSource.pushSegments("video-700700", 1);
+        return m3u8;
+      });
+
+    const recorder = new HLSRecorder(mockLiveUri, {
+      recordDuration: -1,
+      windowSize: -1,
+      vod: true,
+    });
+    recorder.on("mseq-increment", async (data: { allPlaylistSegments: ISegments }) => {
+      // const variants = Object.keys(data.allPlaylistSegments["video"]);
+      // const variantData = data.allPlaylistSegments["video"][variants[0]];
+      // console.log(`Recorded Segments: ${JSON.stringify(variantData, null, 2)}`);
+      LAST_RETURNED_EVENT_DATA = data;
+    });
+    recorder.on("error", (err: any) => {
+      throw new Error("Something Bad Happend (>.<)" + err);
+    });
+
+    spyOn(recorder, "_timer").and.callFake(() => Promise.resolve());
+    await recorder.start();
+
+    const variants = Object.keys(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"]);
+    variants.forEach((variant) => {
+      const lastIndex =
+        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList.length - 1;
+      // Check First Segment
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[0].index).toBe(
+        1
+      );
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[0].uri).toBe(
+        `https://mock.mock.com/live/video-${variant}-seg_0.ts`
+      );
+      // Check Second-to-Last Segment
+      expect(
+        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[lastIndex - 1].index
+      ).toBe(targetEndlistIndex);
+      expect(
+        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[lastIndex - 1].uri
+      ).toBe(`https://mock.mock.com/live/video-${variant}-seg_${targetEndlistIndex - 1}.ts`);
+      // Check Last Segment
+      expect(
+        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[lastIndex].index
+      ).toBe(null);
+      expect(
+        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[lastIndex].endlist
+      ).toBe(true);
+      // Bonus
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].mediaSeq).toBe(0); // Event stream is on the same mseq...
+    });
+  });
+
+  // Test 3
+  it("should record Live type HLS stream, with KEY tag.", async () => {
+    let LAST_RETURNED_EVENT_DATA: any;
+    const targetEndlistIndex = 15;
+    const mockHLSSource = new MockLiveM3U8Generator();
+    const config: IMultiVariantOptions = {
+      videoTracks: vTracks,
+      audioTracks: [],
+      subtitleTracks: [],
+    };
+    mockHLSSource.setMultiVariant(config);
+    mockHLSSource.setInitPlaylistData({
+      MSEQ: 0,
+      DSEQ: 0,
+      TARGET_DUR: 10, // duration for all segments in playlist
+      START_ON: 0, // top segment in playlist has this index
+      END_ON: 6, // last segement in playlist h as this index
+    });
+    mockHLSSource.insertAt("#EXT-X-ENDLIST", targetEndlistIndex);
+
+    nock(mockBaseUri)
+      .persist()
+      .get("/live/master.m3u8")
+      .reply(200, mockHLSSource.getMultiVariant())
+      .get("/live/level_0.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-500500", true);
+        mockHLSSource.shiftSegments("video-500500", 1);
+        mockHLSSource.pushSegments("video-500500", 1);
+        return m3u8;
+      })
+      .get("/live/level_1.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-700700", true);
+        mockHLSSource.shiftSegments("video-700700", 1);
+        mockHLSSource.pushSegments("video-700700", 1);
+        return m3u8;
+      });
+
+    const recorder = new HLSRecorder(mockLiveUri, {
+      recordDuration: -1,
+      windowSize: -1,
+      vod: true,
+    });
+    recorder.on("mseq-increment", async (data: { allPlaylistSegments: ISegments }) => {
+      // const variants = Object.keys(data.allPlaylistSegments["video"]);
+      // const variantData = data.allPlaylistSegments["video"][variants[0]];
+      // console.log(`Recorded Segments: ${JSON.stringify(variantData, null, 2)}`);
+      LAST_RETURNED_EVENT_DATA = data;
+    });
+    recorder.on("error", (err: any) => {
+      throw new Error("Something Bad Happend (>.<)" + err);
+    });
+
+    spyOn(recorder, "_timer").and.callFake(() => Promise.resolve());
+    await recorder.start();
+
+    const variants = Object.keys(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"]);
+    variants.forEach((variant) => {
+      const lastIndex =
+        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList.length - 1;
+      // Check First Segment
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[0].index).toBe(
+        1
+      );
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[0].uri).toBe(
+        `https://mock.mock.com/live/video-${variant}-seg_0.ts`
+      );
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[0].key).toEqual(
+        {
+          method: "AES-128",
+          uri: "https://mock.mock.com/live/mock-key.bin",
+          iv: null,
+          format: null,
+          formatVersions: null,
+        }
+      );
+      // Check Second-to-Last Segment
+      expect(
+        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[lastIndex - 1].index
+      ).toBe(targetEndlistIndex);
+      expect(
+        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[lastIndex - 1].uri
+      ).toBe(`https://mock.mock.com/live/video-${variant}-seg_${targetEndlistIndex - 1}.ts`);
+      // Check Last Segment
+      expect(
+        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[targetEndlistIndex]
+          .index
+      ).toBe(null);
+      expect(
+        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[targetEndlistIndex]
+          .endlist
+      ).toBe(true);
+      // Bonus
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].mediaSeq).toBe(9);
+    });
+  });
+
+  //Test 4
+  it("should record Live type HLS stream, with MAP tag.", async () => {
+    let LAST_RETURNED_EVENT_DATA: any;
+    const targetEndlistIndex = 20;
+    const mockHLSSource = new MockLiveM3U8Generator();
+    const config: IMultiVariantOptions = {
+      videoTracks: vTracks,
+      audioTracks: [],
+      subtitleTracks: [],
+    };
+    mockHLSSource.setMultiVariant(config);
+    mockHLSSource.setInitPlaylistData({
+      MSEQ: 0,
+      DSEQ: 0,
+      TARGET_DUR: 10, // duration for all segments in playlist
+      START_ON: 0, // top segment in playlist has this index
+      END_ON: 6, // last segement in playlist h as this index
+    });
+    mockHLSSource.insertAt("#EXT-X-ENDLIST", targetEndlistIndex);
+
+    nock(mockBaseUri)
+      .persist()
+      .get("/live/master.m3u8")
+      .reply(200, mockHLSSource.getMultiVariant())
+      .get("/live/level_0.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(
+          EnumStreamType.LIVE,
+          "video-500500",
+          false,
+          true
+        );
+        mockHLSSource.shiftSegments("video-500500", 1);
+        mockHLSSource.pushSegments("video-500500", 1);
+        return m3u8;
+      })
+      .get("/live/level_1.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(
+          EnumStreamType.LIVE,
+          "video-700700",
+          false,
+          true
+        );
+        mockHLSSource.shiftSegments("video-700700", 1);
+        mockHLSSource.pushSegments("video-700700", 1);
+        return m3u8;
+      });
+
+    const recorder = new HLSRecorder(mockLiveUri, {
+      recordDuration: -1,
+      windowSize: -1,
+      vod: true,
+    });
+    recorder.on("mseq-increment", async (data: { allPlaylistSegments: ISegments }) => {
+      // const variants = Object.keys(data.allPlaylistSegments["video"]);
+      // const variantData = data.allPlaylistSegments["video"][variants[0]];
+      // console.log(`Recorded Segments: ${JSON.stringify(variantData, null, 2)}`);
+      LAST_RETURNED_EVENT_DATA = data;
+    });
+    recorder.on("error", (err: any) => {
+      throw new Error("Something Bad Happend (>.<)" + err);
+    });
+
+    spyOn(recorder, "_timer").and.callFake(() => Promise.resolve());
+    await recorder.start();
+
+    const variants = Object.keys(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"]);
+    variants.forEach((variant) => {
+      const lastIndex =
+        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList.length - 1;
+      // Check First Segment
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[0].index).toBe(
+        1
+      );
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[0].uri).toBe(
+        `https://mock.mock.com/live/video-${variant}-seg_0.m4s`
+      );
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[0].map).toEqual(
+        {
+          uri: "https://mock.mock.com/live/mock-init.mp4",
+          byterange: null,
+        }
+      );
+      // Check Second-to-Last Segment
+      expect(
+        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[lastIndex - 1].index
+      ).toBe(targetEndlistIndex);
+      expect(
+        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[lastIndex - 1].uri
+      ).toBe(`https://mock.mock.com/live/video-${variant}-seg_${targetEndlistIndex - 1}.m4s`);
+      // Check Last Segment
+      expect(
+        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[targetEndlistIndex]
+          .index
+      ).toBe(null);
+      expect(
+        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[targetEndlistIndex]
+          .endlist
+      ).toBe(true);
+      // Bonus
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].mediaSeq).toBe(14);
+    });
+  });
+
+  //Test 5
+  it("should record Live type HLS stream, with demuxed audio", async () => {
+    let LAST_RETURNED_EVENT_DATA: any;
+    const mockHLSSource = new MockLiveM3U8Generator();
+    const config: IMultiVariantOptions = {
+      videoTracks: vTracks,
+      audioTracks: aTracks,
+      subtitleTracks: [],
+    };
+    mockHLSSource.setMultiVariant(config);
+    mockHLSSource.setInitPlaylistData({
+      MSEQ: 0,
+      DSEQ: 0,
+      TARGET_DUR: 10, // duration for all segments in playlist
+      START_ON: 0, // top segment in playlist has this index
+      END_ON: 6, // last segement in playlist h as this index
+    });
+    nock(mockBaseUri)
+      .persist()
+      .get("/live/master.m3u8")
+      .reply(200, mockHLSSource.getMultiVariant())
+      .get("/live/level_0.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-500500");
+        mockHLSSource.shiftSegments("video-500500", 1);
+        mockHLSSource.pushSegments("video-500500", 1);
+        return m3u8;
+      })
+      .get("/live/level_1.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-700700");
+        mockHLSSource.shiftSegments("video-700700", 1);
+        mockHLSSource.pushSegments("video-700700", 1);
+        return m3u8;
+      })
+      .get("/live/audio-aac_en.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "audio-aac_en");
+        mockHLSSource.shiftSegments("audio-aac_en", 1);
+        mockHLSSource.pushSegments("audio-aac_en", 1);
+        return m3u8;
+      })
+      .get("/live/audio-aac_sv.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "audio-aac_sv");
+        mockHLSSource.shiftSegments("audio-aac_sv", 1);
+        mockHLSSource.pushSegments("audio-aac_sv", 1);
+        return m3u8;
+      });
+
+    const recorder = new HLSRecorder(mockLiveUri, {
+      recordDuration: 120,
+      windowSize: -1,
+      vod: true,
+    });
+    recorder.on("mseq-increment", async (data: { allPlaylistSegments: ISegments }) => {
+      LAST_RETURNED_EVENT_DATA = data;
+    });
+    recorder.on("error", (err: any) => {
+      throw new Error("Something Bad Happend (>.<)" + err);
+    });
+
+    spyOn(recorder, "_timer").and.callFake(() => Promise.resolve());
+    await recorder.start();
+
+    const videoVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"];
+    const audioVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["audio"];
+
+    const bandwidths = Object.keys(videoVariants);
+    const groups = Object.keys(audioVariants);
+
+    bandwidths.forEach((bw) => {
+      const segList = videoVariants[bw].segList;
+      const lastIdx = segList.length - 1;
+
+      expect(segList[0].index).toBe(1);
+      expect(segList[0].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_0.ts`);
+      //
+      expect(segList[lastIdx - 1].index).toBe(12);
+      expect(segList[lastIdx - 1].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_11.ts`);
+      //
+      expect(segList[lastIdx].index).toBe(null);
+      expect(segList[lastIdx].endlist).toBe(true);
+    });
+
+    groups.forEach((group) => {
+      const langs = Object.keys(audioVariants[group]);
+      langs.forEach((lang) => {
+        const segList = audioVariants[group][lang].segList;
+        const lastIdx = segList.length - 1;
+        expect(segList[0].index).toBe(1);
+        expect(segList[0].uri).toBe(`https://mock.mock.com/live/audio-${group}_${lang}-seg_0.ts`);
+        //
+        expect(segList[lastIdx - 1].index).toBe(12);
+        expect(segList[lastIdx - 1].uri).toBe(
+          `https://mock.mock.com/live/audio-${group}_${lang}-seg_11.ts`
+        );
+        //
+        expect(segList[lastIdx].index).toBe(null);
+        expect(segList[lastIdx].endlist).toBe(true);
+      });
+    });
+  });
+
+  it("should record Live type HLS stream, with subtitles", async () => {
+    let LAST_RETURNED_EVENT_DATA: any;
+    const mockHLSSource = new MockLiveM3U8Generator();
+    const config: IMultiVariantOptions = {
+      videoTracks: vTracks,
+      audioTracks: [],
+      subtitleTracks: sTracks,
+    };
+    mockHLSSource.setMultiVariant(config);
+    mockHLSSource.setInitPlaylistData({
+      MSEQ: 0,
+      DSEQ: 0,
+      TARGET_DUR: 10, // duration for all segments in playlist
+      START_ON: 0, // top segment in playlist has this index
+      END_ON: 6, // last segement in playlist h as this index
+    });
+    nock(mockBaseUri)
+      .persist()
+      .get("/live/master.m3u8")
+      .reply(200, mockHLSSource.getMultiVariant())
+      .get("/live/level_0.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-500500");
+        mockHLSSource.shiftSegments("video-500500", 1);
+        mockHLSSource.pushSegments("video-500500", 1);
+        return m3u8;
+      })
+      .get("/live/level_1.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-700700");
+        mockHLSSource.shiftSegments("video-700700", 1);
+        mockHLSSource.pushSegments("video-700700", 1);
+        return m3u8;
+      })
+      .get("/live/sub-cc_en.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "sub-cc_en");
+        mockHLSSource.shiftSegments("sub-cc_en", 1);
+        mockHLSSource.pushSegments("sub-cc_en", 1);
+        return m3u8;
+      });
+
+    const recorder = new HLSRecorder(mockLiveUri, {
+      recordDuration: 120,
+      windowSize: -1,
+      vod: true,
+    });
+    recorder.on("mseq-increment", async (data: { allPlaylistSegments: ISegments }) => {
+      LAST_RETURNED_EVENT_DATA = data;
+    });
+    recorder.on("error", (err: any) => {
+      throw new Error("Something Bad Happend (>.<)" + err);
+    });
+
+    spyOn(recorder, "_timer").and.callFake(() => Promise.resolve());
+    await recorder.start();
+
+    const videoVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"];
+    const subVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["subtitle"];
+
+    const bandwidths = Object.keys(videoVariants);
+    const groups = Object.keys(subVariants);
+
+    bandwidths.forEach((bw) => {
+      const segList = videoVariants[bw].segList;
+      const lastIdx = segList.length - 1;
+
+      expect(segList[0].index).toBe(1);
+      expect(segList[0].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_0.ts`);
+      //
+      expect(segList[lastIdx - 1].index).toBe(12);
+      expect(segList[lastIdx - 1].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_11.ts`);
+      //
+      expect(segList[lastIdx].index).toBe(null);
+      expect(segList[lastIdx].endlist).toBe(true);
+    });
+
+    groups.forEach((group) => {
+      const langs = Object.keys(subVariants[group]);
+      langs.forEach((lang) => {
+        const segList = subVariants[group][lang].segList;
+        const lastIdx = segList.length - 1;
+        expect(segList[0].index).toBe(1);
+        expect(segList[0].uri).toBe(`https://mock.mock.com/live/sub-${group}_${lang}-seg_0.ts`);
+        //
+        expect(segList[lastIdx - 1].index).toBe(12);
+        expect(segList[lastIdx - 1].uri).toBe(
+          `https://mock.mock.com/live/sub-${group}_${lang}-seg_11.ts`
+        );
+        //
+        expect(segList[lastIdx].index).toBe(null);
+        expect(segList[lastIdx].endlist).toBe(true);
+      });
+    });
+  });
+
+  it("should record Live type HLS stream, with demuxed audio and subtitles", async () => {
+    let LAST_RETURNED_EVENT_DATA: any;
+    const mockHLSSource = new MockLiveM3U8Generator();
+    const config: IMultiVariantOptions = {
+      videoTracks: vTracks,
+      audioTracks: aTracks,
+      subtitleTracks: sTracks,
+    };
+    mockHLSSource.setMultiVariant(config);
+    mockHLSSource.setInitPlaylistData({
+      MSEQ: 0,
+      DSEQ: 0,
+      TARGET_DUR: 10, // duration for all segments in playlist
+      START_ON: 0, // top segment in playlist has this index
+      END_ON: 6, // last segement in playlist h as this index
+    });
+    nock(mockBaseUri)
+      .persist()
+      .get("/live/master.m3u8")
+      .reply(200, mockHLSSource.getMultiVariant())
+      .get("/live/level_0.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-500500");
+        mockHLSSource.shiftSegments("video-500500", 1);
+        mockHLSSource.pushSegments("video-500500", 1);
+        return m3u8;
+      })
+      .get("/live/level_1.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-700700");
+        mockHLSSource.shiftSegments("video-700700", 1);
+        mockHLSSource.pushSegments("video-700700", 1);
+        return m3u8;
+      })
+      .get("/live/audio-aac_en.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "audio-aac_en");
+        mockHLSSource.shiftSegments("audio-aac_en", 1);
+        mockHLSSource.pushSegments("audio-aac_en", 1);
+        return m3u8;
+      })
+      .get("/live/audio-aac_sv.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "audio-aac_sv");
+        mockHLSSource.shiftSegments("audio-aac_sv", 1);
+        mockHLSSource.pushSegments("audio-aac_sv", 1);
+        return m3u8;
+      })
+      .get("/live/sub-cc_en.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "sub-cc_en");
+        mockHLSSource.shiftSegments("sub-cc_en", 1);
+        mockHLSSource.pushSegments("sub-cc_en", 1);
+        return m3u8;
+      });
+
+    const recorder = new HLSRecorder(mockLiveUri, {
+      recordDuration: 120,
+      windowSize: -1,
+      vod: true,
+    });
+    recorder.on("mseq-increment", async (data: { allPlaylistSegments: ISegments }) => {
+      LAST_RETURNED_EVENT_DATA = data;
+    });
+    recorder.on("error", (err: any) => {
+      throw new Error("Something Bad Happend (>.<)" + err);
+    });
+
+    spyOn(recorder, "_timer").and.callFake(() => Promise.resolve());
+    await recorder.start();
+
+    const videoVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"];
+    const audioVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["audio"];
+    const subVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["subtitle"];
+
+    const bandwidths = Object.keys(videoVariants);
+    const aGroups = Object.keys(audioVariants);
+    const sGroups = Object.keys(subVariants);
+
+    bandwidths.forEach((bw) => {
+      const segList = videoVariants[bw].segList;
+      const lastIdx = segList.length - 1;
+
+      expect(segList[0].index).toBe(1);
+      expect(segList[0].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_0.ts`);
+      //
+      expect(segList[lastIdx - 1].index).toBe(12);
+      expect(segList[lastIdx - 1].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_11.ts`);
+      //
+      expect(segList[lastIdx].index).toBe(null);
+      expect(segList[lastIdx].endlist).toBe(true);
+    });
+
+    aGroups.forEach((group) => {
+      const langs = Object.keys(audioVariants[group]);
+      langs.forEach((lang) => {
+        const segList = audioVariants[group][lang].segList;
+        const lastIdx = segList.length - 1;
+        expect(segList[0].index).toBe(1);
+        expect(segList[0].uri).toBe(`https://mock.mock.com/live/audio-${group}_${lang}-seg_0.ts`);
+        //
+        expect(segList[lastIdx - 1].index).toBe(12);
+        expect(segList[lastIdx - 1].uri).toBe(
+          `https://mock.mock.com/live/audio-${group}_${lang}-seg_11.ts`
+        );
+        //
+        expect(segList[lastIdx].index).toBe(null);
+        expect(segList[lastIdx].endlist).toBe(true);
+      });
+    });
+
+    sGroups.forEach((group) => {
+      const langs = Object.keys(subVariants[group]);
+      langs.forEach((lang) => {
+        const segList = subVariants[group][lang].segList;
+        const lastIdx = segList.length - 1;
+        expect(segList[0].index).toBe(1);
+        expect(segList[0].uri).toBe(`https://mock.mock.com/live/sub-${group}_${lang}-seg_0.ts`);
+        //
+        expect(segList[lastIdx - 1].index).toBe(12);
+        expect(segList[lastIdx - 1].uri).toBe(
+          `https://mock.mock.com/live/sub-${group}_${lang}-seg_11.ts`
+        );
+        //
+        expect(segList[lastIdx].index).toBe(null);
+        expect(segList[lastIdx].endlist).toBe(true);
+      });
+    });
+  });
+
+  it("should record Live type HLS stream, obtain cookies if any and pass cookieJar in 'mseq-increment' event", async () => {});
+
+  it("should record Live type HLS stream, with a sliding window if set", async () => {});
+
+  it("should record Live type HLS stream, ----- ", async () => {});
+});
+
+/**
+ * 
+      let mm = await GenerateMediaM3U8(500500, {
+      targetDuration: 10,
+      mseq: 16,
+      allSegments: LAST_RETURNED_EVENT_DATA.allPlaylistSegments,
+    });
+    console.log(mm);
+
+
+    nock(mockBaseUri)
+      .persist()
+      .get("/live/master.m3u8")
+      .reply(200, mockHLSSource.getMultiVariant())
+      .get("/live/level_0.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-500500");
+        mockHLSSource.shiftSegments("video-500500", 1);
+        mockHLSSource.pushSegments("video-500500", 1);
+        return m3u8;
+      })
+      .get("/live/level_1.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-700700");
+        mockHLSSource.shiftSegments("video-700700", 1);
+        mockHLSSource.pushSegments("video-700700", 1);
+        return m3u8;
+      })
+      .get("/live/audio-aac_en.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "audio-aac_en");
+        mockHLSSource.shiftSegments("audio-aac_en", 1);
+        mockHLSSource.pushSegments("audio-aac_en", 1);
+        return m3u8;
+      })
+      .get("/live/audio-aac_sv.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "audio-aac_sv");
+        mockHLSSource.shiftSegments("audio-aac_sv", 1);
+        mockHLSSource.pushSegments("audio-aac_sv", 1);
+        return m3u8;
+      })
+      .get("/live/sub-cc_en.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "sub-cc_en");
+        mockHLSSource.shiftSegments("sub-cc_en", 1);
+        mockHLSSource.pushSegments("sub-cc_en", 1);
+        return m3u8;
+      });
+ */

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -1,17 +1,14 @@
 const nock = require("nock");
-import { exitCode } from "process";
-import { HLSRecorder, ISegments } from "..";
-import { GenerateMediaM3U8 } from "../util/manifest_generator";
+import { HLSRecorder, IMseqIncrementEventPayload, ISegments, PlaylistType } from "..";
 import {
   MockLiveM3U8Generator,
-  ILiveStreamPlaylistMetadata,
   EnumStreamType,
-  IMultiVariantOptions,
+  ISetMultiVariantInput,
+  ISetInitPlaylistDataInput,
 } from "./support/MockLiveM3U8Generator";
 
 const mockBaseUri = "https://mock.mock.com/";
 const mockLiveUri = "https://mock.mock.com/live/master.m3u8";
-const tsNow = Date.now();
 const vTracks = [
   {
     bandwidth: 500500,
@@ -49,19 +46,13 @@ const sTracks = [
   },
 ];
 
+// HLSRecorder: BASE
 describe("HLSRecorder", () => {
+  let mockHLSSource: MockLiveM3U8Generator;
   beforeEach(() => {
     jasmine.clock().install();
-  });
-  afterEach(() => {
-    jasmine.clock().uninstall();
-    nock.cleanAll();
-  });
-  // Test 1
-  it("should record Live type HLS stream, and end recording when target duration is reached", async () => {
-    let LAST_RETURNED_EVENT_DATA: any;
-    const mockHLSSource = new MockLiveM3U8Generator();
-    const config: IMultiVariantOptions = {
+    mockHLSSource = new MockLiveM3U8Generator();
+    const config: ISetMultiVariantInput = {
       videoTracks: vTracks,
       audioTracks: [],
       subtitleTracks: [],
@@ -70,9 +61,9 @@ describe("HLSRecorder", () => {
     mockHLSSource.setInitPlaylistData({
       MSEQ: 0,
       DSEQ: 0,
-      TARGET_DUR: 10, // duration for all segments in playlist
-      START_ON: 0, // top segment in playlist has this index
-      END_ON: 6, // last segement in playlist h as this index
+      TARGET_DUR: 10,
+      START_ON: 0,
+      END_ON: 6,
     });
     nock(mockBaseUri)
       .persist()
@@ -90,6 +81,154 @@ describe("HLSRecorder", () => {
         const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-700700");
         mockHLSSource.shiftSegments("video-700700", 1);
         mockHLSSource.pushSegments("video-700700", 1);
+        return m3u8;
+      });
+  });
+  afterEach(() => {
+    jasmine.clock().uninstall();
+    nock.cleanAll();
+  });
+  it("should record Live type HLS stream, and end recording when target duration is reached", async () => {
+    let LAST_RETURNED_EVENT_DATA: IMseqIncrementEventPayload | any;
+    const recorder = new HLSRecorder(mockLiveUri, {
+      recordDuration: 120,
+      windowSize: -1,
+      vod: true,
+    });
+    recorder.on("mseq-increment", async (data: IMseqIncrementEventPayload) => {
+      // const variants = Object.keys(data.allPlaylistSegments["video"]);
+      // const variantData = data.allPlaylistSegments["video"][variants[0]];
+      // console.log(`Recorded Segments: ${JSON.stringify(variantData, null, 2)}`);
+      LAST_RETURNED_EVENT_DATA = data;
+    });
+    recorder.on("error", (err: any) => {
+      throw new Error("Something Bad Happend (>.<)" + err);
+    });
+
+    spyOn(recorder, "_timer").and.callFake(() => Promise.resolve());
+    await recorder.start();
+
+    const videoVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"];
+    const bandwidths = Object.keys(videoVariants);
+    bandwidths.forEach((bw) => {
+      const segList = videoVariants[bw].segList;
+      const lastIdx = segList.length - 1;
+
+      expect(segList[0].index).toBe(1);
+      expect(segList[0].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_0.ts`);
+      //
+      expect(segList[lastIdx - 1].index).toBe(12);
+      expect(segList[lastIdx - 1].uri).toBe(
+        `https://mock.mock.com/live/video-${bw}-seg_${lastIdx - 1}.ts`
+      );
+      //
+      expect(segList[lastIdx].index).toBe(null);
+      expect(segList[lastIdx].endlist).toBe(true);
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][bw].mediaSeq).toBe(6);
+    });
+  });
+  it("should record Event type HLS stream, and end recording when target duration is reached", async () => {
+    let LAST_RETURNED_EVENT_DATA: any;
+    nock.cleanAll();
+    const _mockHLSSource = new MockLiveM3U8Generator();
+    const config: ISetMultiVariantInput = {
+      videoTracks: vTracks,
+      audioTracks: [],
+      subtitleTracks: [],
+    };
+    _mockHLSSource.setMultiVariant(config);
+    _mockHLSSource.setInitPlaylistData({
+      MSEQ: 0,
+      DSEQ: 0,
+      TARGET_DUR: 10, // duration for all segments in playlist
+      START_ON: 0, // top segment in playlist has this index
+      END_ON: 6, // last segement in playlist h as this index
+    });
+    nock(mockBaseUri)
+      .persist()
+      .get("/live/master.m3u8")
+      .reply(200, _mockHLSSource.getMultiVariant())
+      .get("/live/level_0.m3u8")
+      .reply(200, () => {
+        const m3u8 = _mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.EVENT, "video-500500");
+        _mockHLSSource.pushSegments("video-500500", 1);
+        return m3u8;
+      })
+      .get("/live/level_1.m3u8")
+      .reply(200, () => {
+        const m3u8 = _mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.EVENT, "video-700700");
+        _mockHLSSource.pushSegments("video-700700", 1);
+        return m3u8;
+      });
+
+    const recorder = new HLSRecorder(mockLiveUri, {
+      recordDuration: 200,
+      windowSize: -1,
+      vod: true,
+    });
+    recorder.on("mseq-increment", async (data: IMseqIncrementEventPayload) => {
+      LAST_RETURNED_EVENT_DATA = data;
+    });
+    recorder.on("error", (err: any) => {
+      throw new Error("Something Bad Happend (>.<)" + err);
+    });
+
+    spyOn(recorder, "_timer").and.callFake(() => Promise.resolve());
+    await recorder.start();
+
+    const videoVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"];
+    const bandwidths = Object.keys(videoVariants);
+    bandwidths.forEach((bw) => {
+      const segList = videoVariants[bw].segList;
+      const lastIdx = segList.length - 1;
+
+      expect(segList[0].index).toBe(1);
+      expect(segList[0].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_0.ts`);
+      //
+      expect(segList[lastIdx - 1].index).toBe(20);
+      expect(segList[lastIdx - 1].uri).toBe(
+        `https://mock.mock.com/live/video-${bw}-seg_${lastIdx - 1}.ts`
+      );
+      //
+      expect(segList[lastIdx].index).toBe(null);
+      expect(segList[lastIdx].endlist).toBe(true);
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][bw].mediaSeq).toBe(0);
+    });
+  });
+  it("should record VOD type HLS stream, and end recording when target duration is reached", async () => {
+    let LAST_RETURNED_EVENT_DATA: IMseqIncrementEventPayload | any;
+    nock.cleanAll();
+    const _mockHLSSource = new MockLiveM3U8Generator();
+    const config: ISetMultiVariantInput = {
+      videoTracks: vTracks,
+      audioTracks: [],
+      subtitleTracks: [],
+    };
+    _mockHLSSource.setMultiVariant(config);
+    _mockHLSSource.setInitPlaylistData({
+      MSEQ: 1,
+      DSEQ: 0,
+      TARGET_DUR: 10, // duration for all segments in playlist
+      START_ON: 0, // top segment in playlist has this index
+      END_ON: 16, // last segement in playlist h as this index
+    });
+    _mockHLSSource.insertAt({
+      replacementString: `#EXT-X-ENDLIST`,
+      targetSegmentIndex: 16,
+      stopAfter: true,
+    });
+    nock(mockBaseUri)
+      .persist()
+      .get("/live/master.m3u8")
+      .reply(200, _mockHLSSource.getMultiVariant())
+      .get("/live/level_0.m3u8")
+      .reply(200, () => {
+        const m3u8 = _mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.VOD, "video-500500");
+        return m3u8;
+      })
+      .get("/live/level_1.m3u8")
+      .reply(200, () => {
+        const m3u8 = _mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.VOD, "video-700700");
         return m3u8;
       });
 
@@ -98,10 +237,7 @@ describe("HLSRecorder", () => {
       windowSize: -1,
       vod: true,
     });
-    recorder.on("mseq-increment", async (data: { allPlaylistSegments: ISegments }) => {
-      // const variants = Object.keys(data.allPlaylistSegments["video"]);
-      // const variantData = data.allPlaylistSegments["video"][variants[0]];
-      // console.log(`Recorded Segments: ${JSON.stringify(variantData, null, 2)}`);
+    recorder.on("mseq-increment", async (data: IMseqIncrementEventPayload) => {
       LAST_RETURNED_EVENT_DATA = data;
     });
     recorder.on("error", (err: any) => {
@@ -111,81 +247,92 @@ describe("HLSRecorder", () => {
     spyOn(recorder, "_timer").and.callFake(() => Promise.resolve());
     await recorder.start();
 
-    const variants = Object.keys(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"]);
-    variants.forEach((variant) => {
-      const lastIndex =
-        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList.length - 1;
-      // Check First Segment
-      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[0].index).toBe(
-        1
+    const videoVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"];
+    const bandwidths = Object.keys(videoVariants);
+    bandwidths.forEach((bw) => {
+      const segList = videoVariants[bw].segList;
+      const lastIdx = segList.length - 1;
+
+      expect(segList[0].index).toBe(1);
+      expect(segList[0].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_0.ts`);
+      //
+      expect(segList[lastIdx - 1].index).toBe(16);
+      expect(segList[lastIdx - 1].uri).toBe(
+        `https://mock.mock.com/live/video-${bw}-seg_${lastIdx - 1}.ts`
       );
-      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[0].uri).toBe(
-        `https://mock.mock.com/live/video-${variant}-seg_0.ts`
-      );
-      // Check Second-to-Last Segment
-      expect(
-        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[lastIndex - 1].index
-      ).toBe(12);
-      expect(
-        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[lastIndex - 1].uri
-      ).toBe(`https://mock.mock.com/live/video-${variant}-seg_11.ts`);
-      // Check Last Segment
-      expect(
-        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[lastIndex].index
-      ).toBe(null);
-      expect(
-        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[lastIndex].endlist
-      ).toBe(true);
-      // Bonus
-      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].mediaSeq).toBe(6); // Six Iterations Since Start...
+      //
+      expect(segList[lastIdx].index).toBe(null);
+      expect(segList[lastIdx].endlist).toBe(true);
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][bw].mediaSeq).toBe(1);
     });
   });
-
-  // Test 2
-  it("should record Event type HLS stream, and end recording when #EXT-X-ENDLIST appears in HLS stream", async () => {
-    let LAST_RETURNED_EVENT_DATA: any;
-    const targetEndlistIndex = 15;
-    const mockHLSSource = new MockLiveM3U8Generator();
-    const config: IMultiVariantOptions = {
-      videoTracks: vTracks,
-      audioTracks: [],
-      subtitleTracks: [],
-    };
-    mockHLSSource.setMultiVariant(config);
-    mockHLSSource.setInitPlaylistData({
-      MSEQ: 0,
-      DSEQ: 0,
-      TARGET_DUR: 10, // duration for all segments in playlist
-      START_ON: 0, // top segment in playlist has this index
-      END_ON: 5, // last segement in playlist h as this index
+  //Test 9
+  it("should record Live type HLS stream, with a sliding window if set", async () => {
+    let LAST_RETURNED_EVENT_DATA: IMseqIncrementEventPayload | any;
+    const targetEndlistIndex = 100;
+    // Mock Source Becomming a VOD,
+    // will slap on an endlist tag at this seg index
+    mockHLSSource.insertAt({
+      replacementString: "#EXT-X-ENDLIST",
+      targetSegmentIndex: targetEndlistIndex,
+      stopAfter: true,
     });
-    mockHLSSource.insertAt("\n#EXT-X-ENDLIST", targetEndlistIndex); // will slap on an endlist tag at this seg index
-    nock(mockBaseUri)
-      .persist()
-      .get("/live/master.m3u8")
-      .reply(200, mockHLSSource.getMultiVariant())
-      .get("/live/level_0.m3u8")
-      .reply(200, () => {
-        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-500500");
-        mockHLSSource.pushSegments("video-500500", 1);
-        return m3u8;
-      })
-      .get("/live/level_1.m3u8")
-      .reply(200, () => {
-        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-700700");
-        mockHLSSource.pushSegments("video-700700", 1);
-        return m3u8;
-      });
+    const recorder = new HLSRecorder(mockLiveUri, {
+      recordDuration: -1,
+      windowSize: 60,
+      vod: true,
+    });
+    recorder.on("mseq-increment", async (data: IMseqIncrementEventPayload) => {
+      LAST_RETURNED_EVENT_DATA = data;
+    });
+    recorder.on("error", (err: any) => {
+      throw new Error("Something Bad Happend (>.<)" + err);
+    });
+
+    spyOn(recorder, "_timer").and.callFake(() => Promise.resolve());
+    await recorder.start();
+
+    const videoVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"];
+    const bandwidths = Object.keys(videoVariants);
+    bandwidths.forEach((bw) => {
+      const segList = videoVariants[bw].segList;
+      const lastIdx = segList.length - 1;
+      // Check First Segment
+      expect(segList[0].index).toBe(targetEndlistIndex - 5);
+      expect(segList[0].uri).toBe(
+        `https://mock.mock.com/live/video-${bw}-seg_${targetEndlistIndex - 5 - 1}.ts`
+      );
+      // Check Second-to-Last Segment
+      expect(segList[lastIdx - 1].index).toBe(targetEndlistIndex);
+      expect(segList[lastIdx - 1].uri).toBe(
+        `https://mock.mock.com/live/video-${bw}-seg_${targetEndlistIndex - 1}.ts`
+      );
+      // Check Last Segment
+      expect(segList[lastIdx].index).toBe(null);
+      expect(segList[lastIdx].endlist).toBe(true);
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][bw].mediaSeq).toBe(
+        targetEndlistIndex - 5 - 1
+      ); // Event stream is on the same mseq...
+    });
+  });
+  it("should record Live type HLS stream, and if no window size is set, it should still slide according to default window size", async () => {
+    let LAST_RETURNED_EVENT_DATA: IMseqIncrementEventPayload | any;
+    const targetEndlistIndex = 200;
+    const DEFAULT_MAX_WINDOW_SIZE = 5 * 60;
+    // Mock Source Becomming a VOD,
+    // will slap on an endlist tag at this seg index
+    mockHLSSource.insertAt({
+      replacementString: "#EXT-X-ENDLIST",
+      targetSegmentIndex: targetEndlistIndex,
+      stopAfter: true,
+    });
 
     const recorder = new HLSRecorder(mockLiveUri, {
       recordDuration: -1,
       windowSize: -1,
       vod: true,
     });
-    recorder.on("mseq-increment", async (data: { allPlaylistSegments: ISegments }) => {
-      // const variants = Object.keys(data.allPlaylistSegments["video"]);
-      // const variantData = data.allPlaylistSegments["video"][variants[0]];
-      // console.log(`Recorded Segments: ${JSON.stringify(variantData, null, 2)}`);
+    recorder.on("mseq-increment", async (data: IMseqIncrementEventPayload) => {
       LAST_RETURNED_EVENT_DATA = data;
     });
     recorder.on("error", (err: any) => {
@@ -195,42 +342,38 @@ describe("HLSRecorder", () => {
     spyOn(recorder, "_timer").and.callFake(() => Promise.resolve());
     await recorder.start();
 
-    const variants = Object.keys(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"]);
-    variants.forEach((variant) => {
-      const lastIndex =
-        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList.length - 1;
+    const videoVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"];
+    const bandwidths = Object.keys(videoVariants);
+    bandwidths.forEach((bw) => {
+      const segList = videoVariants[bw].segList;
+      const lastIdx = segList.length - 1;
+
+      expect(segList.length).toBe(DEFAULT_MAX_WINDOW_SIZE / 10 + 1);
       // Check First Segment
-      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[0].index).toBe(
-        1
-      );
-      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[0].uri).toBe(
-        `https://mock.mock.com/live/video-${variant}-seg_0.ts`
-      );
+      expect(segList[0].index).toBe(171);
+      expect(segList[0].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_${170}.ts`);
       // Check Second-to-Last Segment
-      expect(
-        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[lastIndex - 1].index
-      ).toBe(targetEndlistIndex);
-      expect(
-        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[lastIndex - 1].uri
-      ).toBe(`https://mock.mock.com/live/video-${variant}-seg_${targetEndlistIndex - 1}.ts`);
+      expect(segList[lastIdx - 1].index).toBe(targetEndlistIndex);
+      expect(segList[lastIdx - 1].uri).toBe(
+        `https://mock.mock.com/live/video-${bw}-seg_${targetEndlistIndex - 1}.ts`
+      );
       // Check Last Segment
-      expect(
-        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[lastIndex].index
-      ).toBe(null);
-      expect(
-        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[lastIndex].endlist
-      ).toBe(true);
-      // Bonus
-      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].mediaSeq).toBe(0); // Event stream is on the same mseq...
+      expect(segList[lastIdx].index).toBe(null);
+      expect(segList[lastIdx].endlist).toBe(true);
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][bw].mediaSeq).toBe(
+        targetEndlistIndex - 5 - 1
+      );
     });
   });
+});
 
-  // Test 3
-  it("should record Live type HLS stream, with KEY tag.", async () => {
-    let LAST_RETURNED_EVENT_DATA: any;
-    const targetEndlistIndex = 15;
-    const mockHLSSource = new MockLiveM3U8Generator();
-    const config: IMultiVariantOptions = {
+// HLSRecorder: ENCRYPTED
+describe("HLSRecorder, when source is encrypted,", () => {
+  let mockHLSSource: MockLiveM3U8Generator;
+  beforeEach(() => {
+    jasmine.clock().install();
+    mockHLSSource = new MockLiveM3U8Generator();
+    const config: ISetMultiVariantInput = {
       videoTracks: vTracks,
       audioTracks: [],
       subtitleTracks: [],
@@ -243,26 +386,41 @@ describe("HLSRecorder", () => {
       START_ON: 0, // top segment in playlist has this index
       END_ON: 6, // last segement in playlist h as this index
     });
-    mockHLSSource.insertAt("#EXT-X-ENDLIST", targetEndlistIndex);
-
     nock(mockBaseUri)
       .persist()
       .get("/live/master.m3u8")
       .reply(200, mockHLSSource.getMultiVariant())
       .get("/live/level_0.m3u8")
       .reply(200, () => {
-        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-500500", true);
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-500500", {
+          keyString: `#EXT-X-KEY:METHOD=AES-128,URI="mock-key.bin",IV=5432554205,KEYFORMAT="mock",KEYFORMATVERSIONS="1/2/5"`,
+        });
         mockHLSSource.shiftSegments("video-500500", 1);
         mockHLSSource.pushSegments("video-500500", 1);
         return m3u8;
       })
       .get("/live/level_1.m3u8")
       .reply(200, () => {
-        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-700700", true);
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-700700", {
+          keyString: `#EXT-X-KEY:METHOD=AES-128,URI="mock-key.bin",IV=5432554205,KEYFORMAT="mock",KEYFORMATVERSIONS="1/2/5"`,
+        });
         mockHLSSource.shiftSegments("video-700700", 1);
         mockHLSSource.pushSegments("video-700700", 1);
         return m3u8;
       });
+  });
+  afterEach(() => {
+    jasmine.clock().uninstall();
+    nock.cleanAll();
+  });
+  it("should record Live type HLS stream, and handle #EXT-X-KEY tag.", async () => {
+    let LAST_RETURNED_EVENT_DATA: any;
+    const targetEndlistIndex = 15;
+    mockHLSSource.insertAt({
+      replacementString: "#EXT-X-ENDLIST",
+      targetSegmentIndex: targetEndlistIndex,
+      stopAfter: true,
+    });
 
     const recorder = new HLSRecorder(mockLiveUri, {
       recordDuration: -1,
@@ -270,9 +428,6 @@ describe("HLSRecorder", () => {
       vod: true,
     });
     recorder.on("mseq-increment", async (data: { allPlaylistSegments: ISegments }) => {
-      // const variants = Object.keys(data.allPlaylistSegments["video"]);
-      // const variantData = data.allPlaylistSegments["video"][variants[0]];
-      // console.log(`Recorded Segments: ${JSON.stringify(variantData, null, 2)}`);
       LAST_RETURNED_EVENT_DATA = data;
     });
     recorder.on("error", (err: any) => {
@@ -282,105 +437,255 @@ describe("HLSRecorder", () => {
     spyOn(recorder, "_timer").and.callFake(() => Promise.resolve());
     await recorder.start();
 
-    const variants = Object.keys(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"]);
-    variants.forEach((variant) => {
-      const lastIndex =
-        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList.length - 1;
-      // Check First Segment
-      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[0].index).toBe(
-        1
+    const videoVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"];
+    const bandwidths = Object.keys(videoVariants);
+    bandwidths.forEach((bw) => {
+      const segList = videoVariants[bw].segList;
+      const lastIdx = segList.length - 1;
+      expect(segList[0].index).toBe(1);
+      expect(segList[0].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_0.ts`);
+      expect(segList[0].key).toEqual({
+        method: "AES-128",
+        uri: "https://mock.mock.com/live/mock-key.bin",
+        iv: "5432554205",
+        format: "mock",
+        formatVersions: "1/2/5",
+      });
+      expect(segList[lastIdx - 1].index).toBe(15);
+      expect(segList[lastIdx - 1].uri).toBe(
+        `https://mock.mock.com/live/video-${bw}-seg_${targetEndlistIndex - 1}.ts`
       );
-      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[0].uri).toBe(
-        `https://mock.mock.com/live/video-${variant}-seg_0.ts`
-      );
-      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[0].key).toEqual(
-        {
-          method: "AES-128",
-          uri: "https://mock.mock.com/live/mock-key.bin",
-          iv: null,
-          format: null,
-          formatVersions: null,
-        }
-      );
-      // Check Second-to-Last Segment
-      expect(
-        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[lastIndex - 1].index
-      ).toBe(targetEndlistIndex);
-      expect(
-        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[lastIndex - 1].uri
-      ).toBe(`https://mock.mock.com/live/video-${variant}-seg_${targetEndlistIndex - 1}.ts`);
-      // Check Last Segment
-      expect(
-        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[targetEndlistIndex]
-          .index
-      ).toBe(null);
-      expect(
-        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[targetEndlistIndex]
-          .endlist
-      ).toBe(true);
-      // Bonus
-      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].mediaSeq).toBe(9);
+      expect(segList[targetEndlistIndex].index).toBe(null);
+      expect(segList[targetEndlistIndex].endlist).toBe(true);
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][bw].mediaSeq).toBe(9);
     });
   });
+  it("should record Event type HLS stream, and handle #EXT-X-KEY tag.", async () => {
+    let LAST_RETURNED_EVENT_DATA: any;
+    nock.cleanAll();
+    const targetEndlistIndex = 15;
+    const _mockHLSSource = new MockLiveM3U8Generator();
+    const config: ISetMultiVariantInput = {
+      videoTracks: vTracks,
+      audioTracks: [],
+      subtitleTracks: [],
+    };
+    _mockHLSSource.setMultiVariant(config);
+    const input: ISetInitPlaylistDataInput = {
+      MSEQ: 0,
+      DSEQ: 0,
+      TARGET_DUR: 10,
+      START_ON: 0,
+      END_ON: 6,
+    };
+    _mockHLSSource.setInitPlaylistData(input);
+    nock(mockBaseUri)
+      .persist()
+      .get("/live/master.m3u8")
+      .reply(200, _mockHLSSource.getMultiVariant())
+      .get("/live/level_0.m3u8")
+      .reply(200, () => {
+        const m3u8 = _mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.EVENT, "video-500500", {
+          keyString: `#EXT-X-KEY:METHOD=AES-128,URI="mock-key.bin",IV=5432554205,KEYFORMAT="mock",KEYFORMATVERSIONS="1/2/5"`,
+        });
+        _mockHLSSource.pushSegments("video-500500", 1);
+        return m3u8;
+      })
+      .get("/live/level_1.m3u8")
+      .reply(200, () => {
+        const m3u8 = _mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.EVENT, "video-700700", {
+          keyString: `#EXT-X-KEY:METHOD=AES-128,URI="mock-key.bin",IV=5432554205,KEYFORMAT="mock",KEYFORMATVERSIONS="1/2/5"`,
+        });
+        _mockHLSSource.pushSegments("video-700700", 1);
+        return m3u8;
+      });
+    _mockHLSSource.insertAt({
+      replacementString: "#EXT-X-ENDLIST",
+      targetSegmentIndex: targetEndlistIndex,
+      stopAfter: true,
+    });
 
+    const recorder = new HLSRecorder(mockLiveUri, {
+      recordDuration: -1,
+      windowSize: -1,
+      vod: true,
+    });
+    recorder.on("mseq-increment", async (data: { allPlaylistSegments: ISegments }) => {
+      LAST_RETURNED_EVENT_DATA = data;
+    });
+    recorder.on("error", (err: any) => {
+      throw new Error("Something Bad Happend (>.<)" + err);
+    });
+
+    spyOn(recorder, "_timer").and.callFake(() => Promise.resolve());
+    await recorder.start();
+
+    const videoVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"];
+    const bandwidths = Object.keys(videoVariants);
+    bandwidths.forEach((bw) => {
+      const segList = videoVariants[bw].segList;
+      const lastIdx = segList.length - 1;
+      expect(segList[0].index).toBe(1);
+      expect(segList[0].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_0.ts`);
+      expect(segList[0].key).toEqual({
+        method: "AES-128",
+        uri: "https://mock.mock.com/live/mock-key.bin",
+        iv: "5432554205",
+        format: "mock",
+        formatVersions: "1/2/5",
+      });
+      expect(segList[lastIdx - 1].index).toBe(15);
+      expect(segList[lastIdx - 1].uri).toBe(
+        `https://mock.mock.com/live/video-${bw}-seg_${targetEndlistIndex - 1}.ts`
+      );
+      expect(segList[targetEndlistIndex].index).toBe(null);
+      expect(segList[targetEndlistIndex].endlist).toBe(true);
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][bw].mediaSeq).toBe(0);
+    });
+  });
+  it("should record VOD type HLS stream, and handle #EXT-X-KEY tag.", async () => {
+    let LAST_RETURNED_EVENT_DATA: any;
+    nock.cleanAll();
+    const targetEndlistIndex = 16;
+    const _mockHLSSource = new MockLiveM3U8Generator();
+    const config: ISetMultiVariantInput = {
+      videoTracks: vTracks,
+      audioTracks: [],
+      subtitleTracks: [],
+    };
+    _mockHLSSource.setMultiVariant(config);
+    _mockHLSSource.setInitPlaylistData({
+      MSEQ: 0,
+      DSEQ: 0,
+      TARGET_DUR: 10,
+      START_ON: 0,
+      END_ON: targetEndlistIndex + 1,
+    });
+    _mockHLSSource.insertAt({
+      replacementString: "#EXT-X-ENDLIST",
+      targetSegmentIndex: targetEndlistIndex,
+      stopAfter: true,
+    });
+    nock(mockBaseUri)
+      .persist()
+      .get("/live/master.m3u8")
+      .reply(200, _mockHLSSource.getMultiVariant())
+      .get("/live/level_0.m3u8")
+      .reply(200, () => {
+        const m3u8 = _mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.VOD, "video-500500", {
+          keyString: `#EXT-X-KEY:METHOD=AES-128,URI="mock-key.bin",IV=5432554205,KEYFORMAT="mock",KEYFORMATVERSIONS="1/2/5"`,
+        });
+        return m3u8;
+      })
+      .get("/live/level_1.m3u8")
+      .reply(200, () => {
+        const m3u8 = _mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.VOD, "video-700700", {
+          keyString: `#EXT-X-KEY:METHOD=AES-128,URI="mock-key.bin",IV=5432554205,KEYFORMAT="mock",KEYFORMATVERSIONS="1/2/5"`,
+        });
+        return m3u8;
+      });
+
+    const recorder = new HLSRecorder(mockLiveUri, {
+      recordDuration: -1,
+      windowSize: -1,
+      vod: true,
+    });
+    recorder.on("mseq-increment", async (data: { allPlaylistSegments: ISegments }) => {
+      LAST_RETURNED_EVENT_DATA = data;
+    });
+    recorder.on("error", (err: any) => {
+      throw new Error("Something Bad Happend (>.<)" + err);
+    });
+
+    spyOn(recorder, "_timer").and.callFake(() => Promise.resolve());
+    await recorder.start();
+
+    const videoVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"];
+    const bandwidths = Object.keys(videoVariants);
+    bandwidths.forEach((bw) => {
+      const segList = videoVariants[bw].segList;
+      const lastIdx = segList.length - 1;
+      expect(segList[0].index).toBe(1);
+      expect(segList[0].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_0.ts`);
+      expect(segList[0].key).toEqual({
+        method: "AES-128",
+        uri: "https://mock.mock.com/live/mock-key.bin",
+        iv: "5432554205",
+        format: "mock",
+        formatVersions: "1/2/5",
+      });
+      expect(segList[lastIdx - 1].index).toBe(16);
+      expect(segList[lastIdx - 1].uri).toBe(
+        `https://mock.mock.com/live/video-${bw}-seg_${targetEndlistIndex - 1}.ts`
+      );
+      expect(segList[targetEndlistIndex].index).toBe(null);
+      expect(segList[targetEndlistIndex].endlist).toBe(true);
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][bw].mediaSeq).toBe(0);
+    });
+  });
+});
+
+//HLSRecorder: Fragmented MP4
+describe("HLSRecorder, when source uses fMP4,", () => {
+  let mockHLSSource: MockLiveM3U8Generator;
+  beforeEach(() => {
+    jasmine.clock().install();
+    mockHLSSource = new MockLiveM3U8Generator();
+    const config: ISetMultiVariantInput = {
+      videoTracks: vTracks,
+      audioTracks: [],
+      subtitleTracks: [],
+    };
+    mockHLSSource.setMultiVariant(config);
+    mockHLSSource.setInitPlaylistData({
+      MSEQ: 0,
+      DSEQ: 0,
+      TARGET_DUR: 10,
+      START_ON: 0,
+      END_ON: 6,
+    });
+    nock(mockBaseUri)
+      .persist()
+      .get("/live/master.m3u8")
+      .reply(200, mockHLSSource.getMultiVariant())
+      .get("/live/level_0.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-500500", {
+          mapString: `#EXT-X-MAP:URI="mock-init.mp4"`,
+        });
+        mockHLSSource.shiftSegments("video-500500", 1);
+        mockHLSSource.pushSegments("video-500500", 1);
+        return m3u8;
+      })
+      .get("/live/level_1.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-700700", {
+          mapString: `#EXT-X-MAP:URI="mock-init.mp4"`,
+        });
+        mockHLSSource.shiftSegments("video-700700", 1);
+        mockHLSSource.pushSegments("video-700700", 1);
+        return m3u8;
+      });
+  });
+  afterEach(() => {
+    jasmine.clock().uninstall();
+    nock.cleanAll();
+  });
   //Test 4
-  it("should record Live type HLS stream, with MAP tag.", async () => {
+  it("should record Live type HLS stream, and handle #EXT-X-MAP tag.", async () => {
     let LAST_RETURNED_EVENT_DATA: any;
     const targetEndlistIndex = 20;
-    const mockHLSSource = new MockLiveM3U8Generator();
-    const config: IMultiVariantOptions = {
-      videoTracks: vTracks,
-      audioTracks: [],
-      subtitleTracks: [],
-    };
-    mockHLSSource.setMultiVariant(config);
-    mockHLSSource.setInitPlaylistData({
-      MSEQ: 0,
-      DSEQ: 0,
-      TARGET_DUR: 10, // duration for all segments in playlist
-      START_ON: 0, // top segment in playlist has this index
-      END_ON: 6, // last segement in playlist h as this index
+    mockHLSSource.insertAt({
+      replacementString: "#EXT-X-ENDLIST",
+      targetSegmentIndex: targetEndlistIndex,
+      stopAfter: true,
     });
-    mockHLSSource.insertAt("#EXT-X-ENDLIST", targetEndlistIndex);
-
-    nock(mockBaseUri)
-      .persist()
-      .get("/live/master.m3u8")
-      .reply(200, mockHLSSource.getMultiVariant())
-      .get("/live/level_0.m3u8")
-      .reply(200, () => {
-        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(
-          EnumStreamType.LIVE,
-          "video-500500",
-          false,
-          true
-        );
-        mockHLSSource.shiftSegments("video-500500", 1);
-        mockHLSSource.pushSegments("video-500500", 1);
-        return m3u8;
-      })
-      .get("/live/level_1.m3u8")
-      .reply(200, () => {
-        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(
-          EnumStreamType.LIVE,
-          "video-700700",
-          false,
-          true
-        );
-        mockHLSSource.shiftSegments("video-700700", 1);
-        mockHLSSource.pushSegments("video-700700", 1);
-        return m3u8;
-      });
-
     const recorder = new HLSRecorder(mockLiveUri, {
       recordDuration: -1,
       windowSize: -1,
       vod: true,
     });
     recorder.on("mseq-increment", async (data: { allPlaylistSegments: ISegments }) => {
-      // const variants = Object.keys(data.allPlaylistSegments["video"]);
-      // const variantData = data.allPlaylistSegments["video"][variants[0]];
-      // console.log(`Recorded Segments: ${JSON.stringify(variantData, null, 2)}`);
       LAST_RETURNED_EVENT_DATA = data;
     });
     recorder.on("error", (err: any) => {
@@ -390,49 +695,199 @@ describe("HLSRecorder", () => {
     spyOn(recorder, "_timer").and.callFake(() => Promise.resolve());
     await recorder.start();
 
-    const variants = Object.keys(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"]);
-    variants.forEach((variant) => {
-      const lastIndex =
-        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList.length - 1;
-      // Check First Segment
-      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[0].index).toBe(
-        1
+    const videoVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"];
+    const bandwidths = Object.keys(videoVariants);
+    bandwidths.forEach((bw) => {
+      const segList = videoVariants[bw].segList;
+      const lastIdx = segList.length - 1;
+
+      expect(segList[0].index).toBe(1);
+      expect(segList[0].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_0.m4s`);
+      expect(segList[0].map).toEqual({
+        uri: "https://mock.mock.com/live/mock-init.mp4",
+        byterange: null,
+      });
+      expect(segList[lastIdx - 1].index).toBe(20);
+      expect(segList[lastIdx - 1].uri).toBe(
+        `https://mock.mock.com/live/video-${bw}-seg_${targetEndlistIndex - 1}.m4s`
       );
-      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[0].uri).toBe(
-        `https://mock.mock.com/live/video-${variant}-seg_0.m4s`
-      );
-      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[0].map).toEqual(
-        {
-          uri: "https://mock.mock.com/live/mock-init.mp4",
-          byterange: null,
-        }
-      );
-      // Check Second-to-Last Segment
-      expect(
-        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[lastIndex - 1].index
-      ).toBe(targetEndlistIndex);
-      expect(
-        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[lastIndex - 1].uri
-      ).toBe(`https://mock.mock.com/live/video-${variant}-seg_${targetEndlistIndex - 1}.m4s`);
-      // Check Last Segment
-      expect(
-        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[targetEndlistIndex]
-          .index
-      ).toBe(null);
-      expect(
-        LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].segList[targetEndlistIndex]
-          .endlist
-      ).toBe(true);
-      // Bonus
-      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][variant].mediaSeq).toBe(14);
+      expect(segList[targetEndlistIndex].index).toBe(null);
+      expect(segList[targetEndlistIndex].endlist).toBe(true);
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][bw].mediaSeq).toBe(14);
     });
   });
+  it("should record Event type HLS stream, and handle #EXT-X-MAP tag.", async () => {
+    let LAST_RETURNED_EVENT_DATA: any;
+    nock.cleanAll();
+    const targetEndlistIndex = 20;
+    const _mockHLSSource = new MockLiveM3U8Generator();
+    const config: ISetMultiVariantInput = {
+      videoTracks: vTracks,
+      audioTracks: [],
+      subtitleTracks: [],
+    };
+    _mockHLSSource.setMultiVariant(config);
+    _mockHLSSource.setInitPlaylistData({
+      MSEQ: 0,
+      DSEQ: 0,
+      TARGET_DUR: 10,
+      START_ON: 0,
+      END_ON: 6,
+    });
+    nock(mockBaseUri)
+      .persist()
+      .get("/live/master.m3u8")
+      .reply(200, _mockHLSSource.getMultiVariant())
+      .get("/live/level_0.m3u8")
+      .reply(200, () => {
+        const m3u8 = _mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.EVENT, "video-500500", {
+          mapString: `#EXT-X-MAP:URI="mock-init.mp4"`,
+        });
+        _mockHLSSource.pushSegments("video-500500", 1);
+        return m3u8;
+      })
+      .get("/live/level_1.m3u8")
+      .reply(200, () => {
+        const m3u8 = _mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.EVENT, "video-700700", {
+          mapString: `#EXT-X-MAP:URI="mock-init.mp4"`,
+        });
+        _mockHLSSource.pushSegments("video-700700", 1);
+        return m3u8;
+      });
+    _mockHLSSource.insertAt({
+      replacementString: "#EXT-X-ENDLIST",
+      targetSegmentIndex: targetEndlistIndex,
+      stopAfter: true,
+    });
+    const recorder = new HLSRecorder(mockLiveUri, {
+      recordDuration: -1,
+      windowSize: -1,
+      vod: true,
+    });
+    recorder.on("mseq-increment", async (data: { allPlaylistSegments: ISegments }) => {
+      LAST_RETURNED_EVENT_DATA = data;
+    });
+    recorder.on("error", (err: any) => {
+      throw new Error("Something Bad Happend (>.<)" + err);
+    });
 
+    spyOn(recorder, "_timer").and.callFake(() => Promise.resolve());
+    await recorder.start();
+
+    const videoVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"];
+    const bandwidths = Object.keys(videoVariants);
+    bandwidths.forEach((bw) => {
+      const segList = videoVariants[bw].segList;
+      const lastIdx = segList.length - 1;
+
+      expect(segList[0].index).toBe(1);
+      expect(segList[0].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_0.m4s`);
+      expect(segList[0].map).toEqual({
+        uri: "https://mock.mock.com/live/mock-init.mp4",
+        byterange: null,
+      });
+      expect(segList[lastIdx - 1].index).toBe(20);
+      expect(segList[lastIdx - 1].uri).toBe(
+        `https://mock.mock.com/live/video-${bw}-seg_${targetEndlistIndex - 1}.m4s`
+      );
+      expect(segList[targetEndlistIndex].index).toBe(null);
+      expect(segList[targetEndlistIndex].endlist).toBe(true);
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][bw].mediaSeq).toBe(0);
+    });
+  });
+  it("should record VOD type HLS stream, and handle #EXT-X-MAP tag.", async () => {
+    let LAST_RETURNED_EVENT_DATA: any;
+    nock.cleanAll();
+    const targetEndlistIndex = 20;
+    const _mockHLSSource = new MockLiveM3U8Generator();
+    const config: ISetMultiVariantInput = {
+      videoTracks: vTracks,
+      audioTracks: [],
+      subtitleTracks: [],
+    };
+    _mockHLSSource.setMultiVariant(config);
+    _mockHLSSource.setInitPlaylistData({
+      MSEQ: 0,
+      DSEQ: 0,
+      TARGET_DUR: 10,
+      START_ON: 0,
+      END_ON: targetEndlistIndex + 1,
+    });
+    nock(mockBaseUri)
+      .persist()
+      .get("/live/master.m3u8")
+      .reply(200, _mockHLSSource.getMultiVariant())
+      .get("/live/level_0.m3u8")
+      .reply(200, () => {
+        const m3u8 = _mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.VOD, "video-500500", {
+          mapString: `#EXT-X-MAP:URI="mock-init.mp4"`,
+        });
+        return m3u8;
+      })
+      .get("/live/level_1.m3u8")
+      .reply(200, () => {
+        const m3u8 = _mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.VOD, "video-700700", {
+          mapString: `#EXT-X-MAP:URI="mock-init.mp4"`,
+        });
+        return m3u8;
+      });
+    _mockHLSSource.insertAt({
+      replacementString: "#EXT-X-ENDLIST",
+      targetSegmentIndex: targetEndlistIndex,
+      stopAfter: true,
+    });
+    const recorder = new HLSRecorder(mockLiveUri, {
+      recordDuration: -1,
+      windowSize: -1,
+      vod: true,
+    });
+    recorder.on("mseq-increment", async (data: { allPlaylistSegments: ISegments }) => {
+      LAST_RETURNED_EVENT_DATA = data;
+    });
+    recorder.on("error", (err: any) => {
+      throw new Error("Something Bad Happend (>.<)" + err);
+    });
+
+    spyOn(recorder, "_timer").and.callFake(() => Promise.resolve());
+    await recorder.start();
+
+    const videoVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"];
+    const bandwidths = Object.keys(videoVariants);
+    bandwidths.forEach((bw) => {
+      const segList = videoVariants[bw].segList;
+      const lastIdx = segList.length - 1;
+
+      expect(segList[0].index).toBe(1);
+      expect(segList[0].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_0.m4s`);
+      expect(segList[0].map).toEqual({
+        uri: "https://mock.mock.com/live/mock-init.mp4",
+        byterange: null,
+      });
+      expect(segList[lastIdx - 1].index).toBe(20);
+      expect(segList[lastIdx - 1].uri).toBe(
+        `https://mock.mock.com/live/video-${bw}-seg_${targetEndlistIndex - 1}.m4s`
+      );
+      expect(segList[targetEndlistIndex].index).toBe(null);
+      expect(segList[targetEndlistIndex].endlist).toBe(true);
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][bw].mediaSeq).toBe(0);
+    });
+  });
+});
+
+// HLSRecorder: Multi-tracks
+describe("HLSRecorder, when source has multiple tracks,", () => {
+  beforeEach(() => {
+    jasmine.clock().install();
+  });
+  afterEach(() => {
+    jasmine.clock().uninstall();
+    nock.cleanAll();
+  });
   //Test 5
-  it("should record Live type HLS stream, with demuxed audio", async () => {
+  it("should record Live type HLS stream with demuxed audio, and stop when recordDuration is reached", async () => {
     let LAST_RETURNED_EVENT_DATA: any;
     const mockHLSSource = new MockLiveM3U8Generator();
-    const config: IMultiVariantOptions = {
+    const config: ISetMultiVariantInput = {
       videoTracks: vTracks,
       audioTracks: aTracks,
       subtitleTracks: [],
@@ -441,9 +896,9 @@ describe("HLSRecorder", () => {
     mockHLSSource.setInitPlaylistData({
       MSEQ: 0,
       DSEQ: 0,
-      TARGET_DUR: 10, // duration for all segments in playlist
-      START_ON: 0, // top segment in playlist has this index
-      END_ON: 6, // last segement in playlist h as this index
+      TARGET_DUR: 10,
+      START_ON: 0,
+      END_ON: 6,
     });
     nock(mockBaseUri)
       .persist()
@@ -505,10 +960,8 @@ describe("HLSRecorder", () => {
 
       expect(segList[0].index).toBe(1);
       expect(segList[0].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_0.ts`);
-      //
       expect(segList[lastIdx - 1].index).toBe(12);
       expect(segList[lastIdx - 1].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_11.ts`);
-      //
       expect(segList[lastIdx].index).toBe(null);
       expect(segList[lastIdx].endlist).toBe(true);
     });
@@ -520,22 +973,19 @@ describe("HLSRecorder", () => {
         const lastIdx = segList.length - 1;
         expect(segList[0].index).toBe(1);
         expect(segList[0].uri).toBe(`https://mock.mock.com/live/audio-${group}_${lang}-seg_0.ts`);
-        //
         expect(segList[lastIdx - 1].index).toBe(12);
         expect(segList[lastIdx - 1].uri).toBe(
           `https://mock.mock.com/live/audio-${group}_${lang}-seg_11.ts`
         );
-        //
         expect(segList[lastIdx].index).toBe(null);
         expect(segList[lastIdx].endlist).toBe(true);
       });
     });
   });
-
-  it("should record Live type HLS stream, with subtitles", async () => {
+  it("should record Live type HLS stream with subtitles, and stop when recordDuration is reached", async () => {
     let LAST_RETURNED_EVENT_DATA: any;
     const mockHLSSource = new MockLiveM3U8Generator();
-    const config: IMultiVariantOptions = {
+    const config: ISetMultiVariantInput = {
       videoTracks: vTracks,
       audioTracks: [],
       subtitleTracks: sTracks,
@@ -544,9 +994,9 @@ describe("HLSRecorder", () => {
     mockHLSSource.setInitPlaylistData({
       MSEQ: 0,
       DSEQ: 0,
-      TARGET_DUR: 10, // duration for all segments in playlist
-      START_ON: 0, // top segment in playlist has this index
-      END_ON: 6, // last segement in playlist h as this index
+      TARGET_DUR: 10,
+      START_ON: 0,
+      END_ON: 6,
     });
     nock(mockBaseUri)
       .persist()
@@ -601,10 +1051,8 @@ describe("HLSRecorder", () => {
 
       expect(segList[0].index).toBe(1);
       expect(segList[0].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_0.ts`);
-      //
       expect(segList[lastIdx - 1].index).toBe(12);
       expect(segList[lastIdx - 1].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_11.ts`);
-      //
       expect(segList[lastIdx].index).toBe(null);
       expect(segList[lastIdx].endlist).toBe(true);
     });
@@ -616,22 +1064,19 @@ describe("HLSRecorder", () => {
         const lastIdx = segList.length - 1;
         expect(segList[0].index).toBe(1);
         expect(segList[0].uri).toBe(`https://mock.mock.com/live/sub-${group}_${lang}-seg_0.ts`);
-        //
         expect(segList[lastIdx - 1].index).toBe(12);
         expect(segList[lastIdx - 1].uri).toBe(
           `https://mock.mock.com/live/sub-${group}_${lang}-seg_11.ts`
         );
-        //
         expect(segList[lastIdx].index).toBe(null);
         expect(segList[lastIdx].endlist).toBe(true);
       });
     });
   });
-
-  it("should record Live type HLS stream, with demuxed audio and subtitles", async () => {
+  it("should record Live type HLS stream with demuxed audio and subtitles, and stop when recordDuration is reached", async () => {
     let LAST_RETURNED_EVENT_DATA: any;
     const mockHLSSource = new MockLiveM3U8Generator();
-    const config: IMultiVariantOptions = {
+    const config: ISetMultiVariantInput = {
       videoTracks: vTracks,
       audioTracks: aTracks,
       subtitleTracks: sTracks,
@@ -640,9 +1085,9 @@ describe("HLSRecorder", () => {
     mockHLSSource.setInitPlaylistData({
       MSEQ: 0,
       DSEQ: 0,
-      TARGET_DUR: 10, // duration for all segments in playlist
-      START_ON: 0, // top segment in playlist has this index
-      END_ON: 6, // last segement in playlist h as this index
+      TARGET_DUR: 10,
+      START_ON: 0,
+      END_ON: 6,
     });
     nock(mockBaseUri)
       .persist()
@@ -713,10 +1158,8 @@ describe("HLSRecorder", () => {
 
       expect(segList[0].index).toBe(1);
       expect(segList[0].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_0.ts`);
-      //
       expect(segList[lastIdx - 1].index).toBe(12);
       expect(segList[lastIdx - 1].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_11.ts`);
-      //
       expect(segList[lastIdx].index).toBe(null);
       expect(segList[lastIdx].endlist).toBe(true);
     });
@@ -728,12 +1171,10 @@ describe("HLSRecorder", () => {
         const lastIdx = segList.length - 1;
         expect(segList[0].index).toBe(1);
         expect(segList[0].uri).toBe(`https://mock.mock.com/live/audio-${group}_${lang}-seg_0.ts`);
-        //
         expect(segList[lastIdx - 1].index).toBe(12);
         expect(segList[lastIdx - 1].uri).toBe(
           `https://mock.mock.com/live/audio-${group}_${lang}-seg_11.ts`
         );
-        //
         expect(segList[lastIdx].index).toBe(null);
         expect(segList[lastIdx].endlist).toBe(true);
       });
@@ -746,35 +1187,378 @@ describe("HLSRecorder", () => {
         const lastIdx = segList.length - 1;
         expect(segList[0].index).toBe(1);
         expect(segList[0].uri).toBe(`https://mock.mock.com/live/sub-${group}_${lang}-seg_0.ts`);
-        //
         expect(segList[lastIdx - 1].index).toBe(12);
         expect(segList[lastIdx - 1].uri).toBe(
           `https://mock.mock.com/live/sub-${group}_${lang}-seg_11.ts`
         );
-        //
         expect(segList[lastIdx].index).toBe(null);
         expect(segList[lastIdx].endlist).toBe(true);
       });
     });
   });
+  it("should record Event type HLS stream with demuxed audio and subtitles, and stop when recordDuration is reached", async () => {
+    let LAST_RETURNED_EVENT_DATA: any;
+    const mockHLSSource = new MockLiveM3U8Generator();
+    const config: ISetMultiVariantInput = {
+      videoTracks: vTracks,
+      audioTracks: aTracks,
+      subtitleTracks: sTracks,
+    };
+    mockHLSSource.setMultiVariant(config);
+    mockHLSSource.setInitPlaylistData({
+      MSEQ: 0,
+      DSEQ: 0,
+      TARGET_DUR: 10,
+      START_ON: 0,
+      END_ON: 6,
+    });
+    nock(mockBaseUri)
+      .persist()
+      .get("/live/master.m3u8")
+      .reply(200, mockHLSSource.getMultiVariant())
+      .get("/live/level_0.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.EVENT, "video-500500");
+        mockHLSSource.pushSegments("video-500500", 1);
+        return m3u8;
+      })
+      .get("/live/level_1.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.EVENT, "video-700700");
+        mockHLSSource.pushSegments("video-700700", 1);
+        return m3u8;
+      })
+      .get("/live/audio-aac_en.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.EVENT, "audio-aac_en");
+        mockHLSSource.pushSegments("audio-aac_en", 1);
+        return m3u8;
+      })
+      .get("/live/audio-aac_sv.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.EVENT, "audio-aac_sv");
+        mockHLSSource.pushSegments("audio-aac_sv", 1);
+        return m3u8;
+      })
+      .get("/live/sub-cc_en.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.EVENT, "sub-cc_en");
+        mockHLSSource.pushSegments("sub-cc_en", 1);
+        return m3u8;
+      });
 
-  it("should record Live type HLS stream, obtain cookies if any and pass cookieJar in 'mseq-increment' event", async () => {});
+    const recorder = new HLSRecorder(mockLiveUri, {
+      recordDuration: 120,
+      windowSize: -1,
+      vod: true,
+    });
+    recorder.on("mseq-increment", async (data: { allPlaylistSegments: ISegments }) => {
+      LAST_RETURNED_EVENT_DATA = data;
+    });
+    recorder.on("error", (err: any) => {
+      throw new Error("Something Bad Happend (>.<)" + err);
+    });
 
-  it("should record Live type HLS stream, with a sliding window if set", async () => {});
+    spyOn(recorder, "_timer").and.callFake(() => Promise.resolve());
+    await recorder.start();
 
-  it("should record Live type HLS stream, ----- ", async () => {});
+    const videoVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"];
+    const audioVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["audio"];
+    const subVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["subtitle"];
+
+    const bandwidths = Object.keys(videoVariants);
+    const aGroups = Object.keys(audioVariants);
+    const sGroups = Object.keys(subVariants);
+
+    bandwidths.forEach((bw) => {
+      const segList = videoVariants[bw].segList;
+      const lastIdx = segList.length - 1;
+
+      expect(segList[0].index).toBe(1);
+      expect(segList[0].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_0.ts`);
+      expect(segList[lastIdx - 1].index).toBe(12);
+      expect(segList[lastIdx - 1].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_11.ts`);
+      expect(segList[lastIdx].index).toBe(null);
+      expect(segList[lastIdx].endlist).toBe(true);
+    });
+
+    aGroups.forEach((group) => {
+      const langs = Object.keys(audioVariants[group]);
+      langs.forEach((lang) => {
+        const segList = audioVariants[group][lang].segList;
+        const lastIdx = segList.length - 1;
+        expect(segList[0].index).toBe(1);
+        expect(segList[0].uri).toBe(`https://mock.mock.com/live/audio-${group}_${lang}-seg_0.ts`);
+        expect(segList[lastIdx - 1].index).toBe(12);
+        expect(segList[lastIdx - 1].uri).toBe(
+          `https://mock.mock.com/live/audio-${group}_${lang}-seg_11.ts`
+        );
+        expect(segList[lastIdx].index).toBe(null);
+        expect(segList[lastIdx].endlist).toBe(true);
+      });
+    });
+
+    sGroups.forEach((group) => {
+      const langs = Object.keys(subVariants[group]);
+      langs.forEach((lang) => {
+        const segList = subVariants[group][lang].segList;
+        const lastIdx = segList.length - 1;
+        expect(segList[0].index).toBe(1);
+        expect(segList[0].uri).toBe(`https://mock.mock.com/live/sub-${group}_${lang}-seg_0.ts`);
+        expect(segList[lastIdx - 1].index).toBe(12);
+        expect(segList[lastIdx - 1].uri).toBe(
+          `https://mock.mock.com/live/sub-${group}_${lang}-seg_11.ts`
+        );
+        expect(segList[lastIdx].index).toBe(null);
+        expect(segList[lastIdx].endlist).toBe(true);
+      });
+    });
+  });
+  it("should record VOD type HLS stream with demuxed audio and subtitles", async () => {
+    let LAST_RETURNED_EVENT_DATA: any;
+    const mockHLSSource = new MockLiveM3U8Generator();
+    const targetEndIndex = 36;
+    const config: ISetMultiVariantInput = {
+      videoTracks: vTracks,
+      audioTracks: aTracks,
+      subtitleTracks: sTracks,
+    };
+    mockHLSSource.setMultiVariant(config);
+    mockHLSSource.setInitPlaylistData({
+      MSEQ: 0,
+      DSEQ: 0,
+      TARGET_DUR: 10,
+      START_ON: 0,
+      END_ON: targetEndIndex + 1,
+    });
+    mockHLSSource.insertAt({
+      replacementString: "#EXT-X-ENDLIST",
+      targetSegmentIndex: targetEndIndex,
+      stopAfter: true,
+    });
+    nock(mockBaseUri)
+      .persist()
+      .get("/live/master.m3u8")
+      .reply(200, mockHLSSource.getMultiVariant())
+      .get("/live/level_0.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.VOD, "video-500500");
+        return m3u8;
+      })
+      .get("/live/level_1.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.VOD, "video-700700");
+        return m3u8;
+      })
+      .get("/live/audio-aac_en.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.VOD, "audio-aac_en");
+        return m3u8;
+      })
+      .get("/live/audio-aac_sv.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.VOD, "audio-aac_sv");
+        return m3u8;
+      })
+      .get("/live/sub-cc_en.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.VOD, "sub-cc_en");
+        return m3u8;
+      });
+
+    const recorder = new HLSRecorder(mockLiveUri, {
+      recordDuration: -1,
+      windowSize: -1,
+      vod: true,
+    });
+    recorder.on("mseq-increment", async (data: { allPlaylistSegments: ISegments }) => {
+      LAST_RETURNED_EVENT_DATA = data;
+    });
+    recorder.on("error", (err: any) => {
+      throw new Error("Something Bad Happend (>.<)" + err);
+    });
+
+    spyOn(recorder, "_timer").and.callFake(() => Promise.resolve());
+    await recorder.start();
+
+    const videoVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"];
+    const audioVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["audio"];
+    const subVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["subtitle"];
+
+    const bandwidths = Object.keys(videoVariants);
+    const aGroups = Object.keys(audioVariants);
+    const sGroups = Object.keys(subVariants);
+
+    bandwidths.forEach((bw) => {
+      const segList = videoVariants[bw].segList;
+      const lastIdx = segList.length - 1;
+
+      expect(segList[0].index).toBe(1);
+      expect(segList[0].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_0.ts`);
+      expect(segList[lastIdx - 1].index).toBe(targetEndIndex);
+      expect(segList[lastIdx - 1].uri).toBe(
+        `https://mock.mock.com/live/video-${bw}-seg_${targetEndIndex - 1}.ts`
+      );
+      expect(segList[lastIdx].index).toBe(null);
+      expect(segList[lastIdx].endlist).toBe(true);
+    });
+
+    aGroups.forEach((group) => {
+      const langs = Object.keys(audioVariants[group]);
+      langs.forEach((lang) => {
+        const segList = audioVariants[group][lang].segList;
+        const lastIdx = segList.length - 1;
+        expect(segList[0].index).toBe(1);
+        expect(segList[0].uri).toBe(`https://mock.mock.com/live/audio-${group}_${lang}-seg_0.ts`);
+        expect(segList[lastIdx - 1].index).toBe(targetEndIndex);
+        expect(segList[lastIdx - 1].uri).toBe(
+          `https://mock.mock.com/live/audio-${group}_${lang}-seg_${targetEndIndex - 1}.ts`
+        );
+        expect(segList[lastIdx].index).toBe(null);
+        expect(segList[lastIdx].endlist).toBe(true);
+      });
+    });
+
+    sGroups.forEach((group) => {
+      const langs = Object.keys(subVariants[group]);
+      langs.forEach((lang) => {
+        const segList = subVariants[group][lang].segList;
+        const lastIdx = segList.length - 1;
+        expect(segList[0].index).toBe(1);
+        expect(segList[0].uri).toBe(`https://mock.mock.com/live/sub-${group}_${lang}-seg_0.ts`);
+        expect(segList[lastIdx - 1].index).toBe(targetEndIndex);
+        expect(segList[lastIdx - 1].uri).toBe(
+          `https://mock.mock.com/live/sub-${group}_${lang}-seg_${targetEndIndex - 1}.ts`
+        );
+        expect(segList[lastIdx].index).toBe(null);
+        expect(segList[lastIdx].endlist).toBe(true);
+      });
+    });
+  });
 });
 
-/**
- * 
-      let mm = await GenerateMediaM3U8(500500, {
-      targetDuration: 10,
-      mseq: 16,
-      allSegments: LAST_RETURNED_EVENT_DATA.allPlaylistSegments,
+// HLSRecorder: Cookies
+describe("HLSRecorder, when source requires cookie", () => {
+  beforeEach(() => {
+    jasmine.clock().install();
+  });
+  afterEach(() => {
+    jasmine.clock().uninstall();
+    nock.cleanAll();
+  });
+  it("should record Live type HLS stream, obtain cookies if any and pass cookieJar in 'mseq-increment' event", async () => {
+    let LAST_RETURNED_EVENT_DATA: any;
+    const targetEndlistIndex = 20;
+    const mockHLSSource = new MockLiveM3U8Generator();
+    const config: ISetMultiVariantInput = {
+      videoTracks: vTracks,
+      audioTracks: [],
+      subtitleTracks: [],
+    };
+    mockHLSSource.setMultiVariant(config);
+    mockHLSSource.setInitPlaylistData({
+      MSEQ: 0,
+      DSEQ: 0,
+      TARGET_DUR: 10, // duration for all segments in playlist
+      START_ON: 0, // top segment in playlist has this index
+      END_ON: 6, // last segement in playlist h as this index
     });
-    console.log(mm);
+    // Mock Source Becomming a VOD,
+    // will slap on an endlist tag at this seg index
+    mockHLSSource.insertAt({
+      replacementString: "#EXT-X-ENDLIST",
+      targetSegmentIndex: targetEndlistIndex,
+      stopAfter: true,
+    });
+    nock(mockBaseUri)
+      .persist()
+      .get("/live/master.m3u8")
+      .reply(200, mockHLSSource.getMultiVariant(), {
+        "Content-Type": "application/x-mpegURL;charset=UTF-8",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "no-cache",
+        "strict-transport-security": "max-age=31536000; includeSubDomains",
+        "cache-control": "public, max-age=60",
+        "access-control-allow-credentials": "true",
+        "set-cookie": "jwt=eyJhbGcihw; HttpOnly; SameSite=None; Path=/live",
+        "access-control-max-age": "600",
+      })
+      .get("/live/level_0.m3u8")
+      .reply(function (uri: string, requestBody: any) {
+        if (!this.req.headers["cookie"].includes("jwt=eyJhbGcihw")) {
+          return [201, "Invalid Cookie"];
+        } else {
+          const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-500500");
+          mockHLSSource.pushSegments("video-500500", 1);
+          return [200, m3u8];
+        }
+      })
+      .get("/live/level_1.m3u8")
+      .reply(function (uri: string, requestBody: any) {
+        if (!this.req.headers["cookie"].includes("jwt=eyJhbGcihw")) {
+          return [201, "Invalid Cookie"];
+        } else {
+          const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-700700");
+          mockHLSSource.pushSegments("video-700700", 1);
+          return [200, m3u8];
+        }
+      });
 
+    const recorder = new HLSRecorder(mockLiveUri, {
+      recordDuration: -1,
+      windowSize: -1,
+      vod: true,
+    });
+    recorder.on("mseq-increment", async (data: { allPlaylistSegments: ISegments }) => {
+      LAST_RETURNED_EVENT_DATA = data;
+    });
+    recorder.on("error", (err: any) => {
+      throw new Error("Something Bad Happend (>.<)" + err);
+    });
 
+    spyOn(recorder, "_timer").and.callFake(() => Promise.resolve());
+    await recorder.start();
+
+    const videoVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"];
+    const bandwidths = Object.keys(videoVariants);
+    bandwidths.forEach((bw) => {
+      const segList = videoVariants[bw].segList;
+      const lastIdx = segList.length - 1;
+      // Check First Segment
+      expect(segList[0].index).toBe(1);
+      expect(segList[0].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_0.ts`);
+      // Check Second-to-Last Segment
+      expect(segList[lastIdx - 1].index).toBe(20);
+      expect(segList[lastIdx - 1].uri).toBe(
+        `https://mock.mock.com/live/video-${bw}-seg_${targetEndlistIndex - 1}.ts`
+      );
+      // Check Last Segment
+      expect(segList[targetEndlistIndex].index).toBe(null);
+      expect(segList[targetEndlistIndex].endlist).toBe(true);
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][bw].mediaSeq).toBe(0); // Event stream is on the same mseq...
+    });
+  });
+});
+
+// HLSRecorder: PLAYLIST-TYPE=EVENT
+describe("HLSRecorder, when source is EVENT,", () => {
+  let mockHLSSource: MockLiveM3U8Generator;
+  beforeEach(() => {
+    jasmine.clock().install();
+    mockHLSSource = new MockLiveM3U8Generator();
+    const config: ISetMultiVariantInput = {
+      videoTracks: vTracks,
+      audioTracks: [],
+      subtitleTracks: [],
+    };
+    mockHLSSource.setMultiVariant(config);
+    mockHLSSource.setInitPlaylistData({
+      MSEQ: 0,
+      DSEQ: 0,
+      TARGET_DUR: 10, // duration for all segments in playlist
+      START_ON: 0, // top segment in playlist has this index
+      END_ON: 6, // last segement in playlist h as this index
+    });
     nock(mockBaseUri)
       .persist()
       .get("/live/master.m3u8")
@@ -782,36 +1566,318 @@ describe("HLSRecorder", () => {
       .get("/live/level_0.m3u8")
       .reply(200, () => {
         const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-500500");
-        mockHLSSource.shiftSegments("video-500500", 1);
         mockHLSSource.pushSegments("video-500500", 1);
         return m3u8;
       })
       .get("/live/level_1.m3u8")
       .reply(200, () => {
         const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-700700");
-        mockHLSSource.shiftSegments("video-700700", 1);
         mockHLSSource.pushSegments("video-700700", 1);
         return m3u8;
-      })
-      .get("/live/audio-aac_en.m3u8")
+      });
+  });
+  afterEach(() => {
+    jasmine.clock().uninstall();
+    nock.cleanAll();
+  });
+  it("should record Event type HLS stream, and end recording when #EXT-X-ENDLIST appears in HLS stream", async () => {
+    let LAST_RETURNED_EVENT_DATA: any;
+    const targetEndlistIndex = 15;
+    // Mock Source Becomming a VOD,
+    // will slap on an endlist tag at this seg index
+    mockHLSSource.insertAt({
+      replacementString: "#EXT-X-ENDLIST",
+      targetSegmentIndex: targetEndlistIndex,
+      stopAfter: true,
+    });
+
+    const recorder = new HLSRecorder(mockLiveUri, {
+      recordDuration: -1,
+      windowSize: -1,
+      vod: true,
+    });
+    recorder.on("mseq-increment", async (data: { allPlaylistSegments: ISegments }) => {
+      LAST_RETURNED_EVENT_DATA = data;
+    });
+    recorder.on("error", (err: any) => {
+      throw new Error("Something Bad Happend (>.<)" + err);
+    });
+
+    spyOn(recorder, "_timer").and.callFake(() => Promise.resolve());
+    await recorder.start();
+
+    const videoVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"];
+    const bandwidths = Object.keys(videoVariants);
+    bandwidths.forEach((bw) => {
+      const segList = videoVariants[bw].segList;
+      const lastIdx = segList.length - 1;
+      // Check First Segment
+      expect(segList[0].index).toBe(1);
+      expect(segList[0].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_0.ts`);
+      // Check Second-to-Last Segment
+      expect(segList[lastIdx - 1].index).toBe(15);
+      expect(segList[lastIdx - 1].uri).toBe(
+        `https://mock.mock.com/live/video-${bw}-seg_${targetEndlistIndex - 1}.ts`
+      );
+      // Check Last Segment
+      expect(segList[targetEndlistIndex].index).toBe(null);
+      expect(segList[targetEndlistIndex].endlist).toBe(true);
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][bw].mediaSeq).toBe(0); // Event stream is on the same mseq...
+    });
+  });
+});
+
+describe("HLSRecorder, when source is not perfect,", () => {
+  beforeEach(() => {
+    jasmine.clock().install();
+  });
+  afterEach(() => {
+    jasmine.clock().uninstall();
+    nock.cleanAll();
+  });
+
+  it("should record Live type HLS stream, and handle if source mseq increases more than 1 step", async () => {
+    let LAST_RETURNED_EVENT_DATA: any;
+    const targetEndlistIndex = 21;
+    const mockHLSSource = new MockLiveM3U8Generator();
+    const config: ISetMultiVariantInput = {
+      videoTracks: vTracks,
+      audioTracks: [],
+      subtitleTracks: [],
+    };
+    mockHLSSource.setMultiVariant(config);
+    mockHLSSource.setInitPlaylistData({
+      MSEQ: 0,
+      DSEQ: 0,
+      TARGET_DUR: 10,
+      START_ON: 0,
+      END_ON: 6,
+    });
+    mockHLSSource.insertAt({
+      replacementString: "#EXT-X-ENDLIST",
+      targetSegmentIndex: targetEndlistIndex,
+      stopAfter: true,
+    });
+    nock(mockBaseUri)
+      .persist()
+      .get("/live/master.m3u8")
+      .reply(200, mockHLSSource.getMultiVariant())
+      .get("/live/level_0.m3u8")
       .reply(200, () => {
-        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "audio-aac_en");
-        mockHLSSource.shiftSegments("audio-aac_en", 1);
-        mockHLSSource.pushSegments("audio-aac_en", 1);
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-500500");
+        mockHLSSource.shiftSegments("video-500500", 3);
+        mockHLSSource.pushSegments("video-500500", 3);
         return m3u8;
       })
-      .get("/live/audio-aac_sv.m3u8")
+      .get("/live/level_1.m3u8")
       .reply(200, () => {
-        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "audio-aac_sv");
-        mockHLSSource.shiftSegments("audio-aac_sv", 1);
-        mockHLSSource.pushSegments("audio-aac_sv", 1);
-        return m3u8;
-      })
-      .get("/live/sub-cc_en.m3u8")
-      .reply(200, () => {
-        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "sub-cc_en");
-        mockHLSSource.shiftSegments("sub-cc_en", 1);
-        mockHLSSource.pushSegments("sub-cc_en", 1);
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-700700");
+        mockHLSSource.shiftSegments("video-700700", 3);
+        mockHLSSource.pushSegments("video-700700", 3);
         return m3u8;
       });
- */
+
+    const recorder = new HLSRecorder(mockLiveUri, {
+      recordDuration: -1,
+      windowSize: -1,
+      vod: true,
+    });
+    recorder.on("mseq-increment", async (data: { allPlaylistSegments: ISegments }) => {
+      LAST_RETURNED_EVENT_DATA = data;
+    });
+    recorder.on("error", (err: any) => {
+      throw new Error("Something Bad Happend (>.<)" + err);
+    });
+
+    spyOn(recorder, "_timer").and.callFake(() => Promise.resolve());
+    await recorder.start();
+
+    const videoVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"];
+    const bandwidths = Object.keys(videoVariants);
+    bandwidths.forEach((bw) => {
+      const segList = videoVariants[bw].segList;
+      const lastIdx = segList.length - 1;
+      expect(segList[0].index).toBe(1);
+      expect(segList[0].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_0.ts`);
+      expect(segList[lastIdx - 1].index).toBe(21);
+      expect(segList[lastIdx - 1].uri).toBe(
+        `https://mock.mock.com/live/video-${bw}-seg_${targetEndlistIndex - 1}.ts`
+      );
+      expect(segList[targetEndlistIndex].index).toBe(null);
+      expect(segList[targetEndlistIndex].endlist).toBe(true);
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][bw].mediaSeq).toBe(15);
+    });
+  });
+  it("should record Live type HLS stream, and handle if source mseq accross variants are not synced", async () => {
+    let LAST_RETURNED_EVENT_DATA: any;
+    let countA = 0;
+    let countB = 0;
+    const targetEndlistIndex = 21;
+    const mockHLSSource = new MockLiveM3U8Generator();
+    const config: ISetMultiVariantInput = {
+      videoTracks: vTracks,
+      audioTracks: [],
+      subtitleTracks: [],
+    };
+    mockHLSSource.setMultiVariant(config);
+    mockHLSSource.setInitPlaylistData({
+      MSEQ: 0,
+      DSEQ: 0,
+      TARGET_DUR: 10,
+      START_ON: 0,
+      END_ON: 6,
+    });
+    mockHLSSource.insertAt({
+      replacementString: "#EXT-X-ENDLIST",
+      targetSegmentIndex: targetEndlistIndex,
+      stopAfter: true,
+    });
+    nock(mockBaseUri)
+      .persist()
+      .get("/live/master.m3u8")
+      .reply(200, mockHLSSource.getMultiVariant())
+      .get("/live/level_0.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-500500");
+        countA++;
+        if (countA !== 3) {
+          mockHLSSource.shiftSegments("video-500500", 1);
+          mockHLSSource.pushSegments("video-500500", 1);
+        }
+        return m3u8;
+      })
+      .get("/live/level_1.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-700700");
+        countB++;
+        if (countB !== 4) {
+          mockHLSSource.shiftSegments("video-700700", 1);
+          mockHLSSource.pushSegments("video-700700", 1);
+        }
+        return m3u8;
+      });
+
+    const recorder = new HLSRecorder(mockLiveUri, {
+      recordDuration: -1,
+      windowSize: -1,
+      vod: true,
+    });
+    recorder.on("mseq-increment", async (data: { allPlaylistSegments: ISegments }) => {
+      LAST_RETURNED_EVENT_DATA = data;
+    });
+    recorder.on("error", (err: any) => {
+      throw new Error("Something Bad Happend (>.<)" + err);
+    });
+
+    spyOn(recorder, "_timer").and.callFake(() => Promise.resolve());
+    await recorder.start();
+
+    const videoVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"];
+    const bandwidths = Object.keys(videoVariants);
+    bandwidths.forEach((bw) => {
+      const segList = videoVariants[bw].segList;
+      const lastIdx = segList.length - 1;
+      expect(segList[0].index).toBe(1);
+      expect(segList[0].uri).toBe(`https://mock.mock.com/live/video-${bw}-seg_0.ts`);
+      expect(segList[lastIdx - 1].index).toBe(targetEndlistIndex);
+      expect(segList[lastIdx - 1].uri).toBe(
+        `https://mock.mock.com/live/video-${bw}-seg_${targetEndlistIndex - 1}.ts`
+      );
+      expect(segList[targetEndlistIndex].index).toBe(null);
+      expect(segList[targetEndlistIndex].endlist).toBe(true);
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][bw].mediaSeq).toBe(15);
+    });
+  });
+  it("should record Live type HLS stream, and handle if source is not a multi-variant manifest", async () => {
+    let LAST_RETURNED_EVENT_DATA: any;
+    const targetEndlistIndex = 21;
+    let countA = 0;
+    const mockHLSSource = new MockLiveM3U8Generator();
+    const config: ISetMultiVariantInput = {
+      videoTracks: vTracks,
+      audioTracks: [],
+      subtitleTracks: [],
+    };
+    mockHLSSource.setMultiVariant(config);
+    mockHLSSource.setInitPlaylistData({
+      MSEQ: 0,
+      DSEQ: 0,
+      TARGET_DUR: 10,
+      START_ON: 0,
+      END_ON: 6,
+    });
+    mockHLSSource.insertAt({
+      replacementString: "#EXT-X-ENDLIST",
+      targetSegmentIndex: targetEndlistIndex,
+      stopAfter: true,
+    });
+    nock(mockBaseUri)
+      .persist()
+      .get("/live/video-500500.m3u8")
+      .reply(200, () => {
+        const m3u8 = mockHLSSource.getMediaPlaylistM3U8(EnumStreamType.LIVE, "video-500500");
+        countA++;
+        if (countA !== 1) {
+          mockHLSSource.shiftSegments("video-500500", 1);
+          mockHLSSource.pushSegments("video-500500", 1);
+        }
+        return m3u8;
+      });
+
+    const recorder = new HLSRecorder("https://mock.mock.com/live/video-500500.m3u8", {
+      recordDuration: -1,
+      windowSize: -1,
+      vod: true,
+    });
+    recorder.on("mseq-increment", async (data: { allPlaylistSegments: ISegments }) => {
+      LAST_RETURNED_EVENT_DATA = data;
+    });
+    recorder.on("error", (err: any) => {
+      throw new Error("Something Bad Happend (>.<)" + err);
+    });
+
+    spyOn(recorder, "_timer").and.callFake(() => Promise.resolve());
+    await recorder.start();
+
+    const videoVariants = LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"];
+    const bandwidths = Object.keys(videoVariants);
+    bandwidths.forEach((bw) => {
+      const segList = videoVariants[bw].segList;
+      const lastIdx = segList.length - 1;
+      expect(segList[0].index).toBe(1);
+      expect(segList[0].uri).toBe(`https://mock.mock.com/live/video-500500-seg_0.ts`);
+      expect(segList[lastIdx - 1].index).toBe(21);
+      expect(segList[lastIdx - 1].uri).toBe(
+        `https://mock.mock.com/live/video-500500-seg_${targetEndlistIndex - 1}.ts`
+      );
+      expect(segList[targetEndlistIndex].index).toBe(null);
+      expect(segList[targetEndlistIndex].endlist).toBe(true);
+      expect(LAST_RETURNED_EVENT_DATA.allPlaylistSegments["video"][bw].mediaSeq).toBe(15);
+    });
+  });
+});
+
+// TODO: Test Channel Engine Support
+describe("HLSRecorder, when ", () => {
+  beforeEach(() => {
+    jasmine.clock().install();
+  });
+  afterEach(() => {
+    jasmine.clock().uninstall();
+    nock.cleanAll();
+  });
+
+  it("should record Live type HLS stream, ----- ", async () => {});
+});
+// TODO: Test error/failing cases
+describe("HLSRecorder, when ", () => {
+  beforeEach(() => {
+    jasmine.clock().install();
+  });
+  afterEach(() => {
+    jasmine.clock().uninstall();
+    nock.cleanAll();
+  });
+
+  it("should record Live type HLS stream, ----- ", async () => {});
+});

--- a/spec/support/MockLiveM3U8Generator.ts
+++ b/spec/support/MockLiveM3U8Generator.ts
@@ -1,0 +1,215 @@
+export interface IVideoTracks {
+  bandwidth: number;
+  width: number;
+  height: number;
+  codecs: string;
+  frameRate?: number;
+  audio?: string;
+  subtitle?: string;
+}
+
+export interface IMultiVariantOptions {
+  videoTracks: IVideoTracks[];
+  audioTracks?: IExtraTracks[];
+  subtitleTracks?: IExtraTracks[];
+}
+
+export interface IExtraTracks {
+  groupId: string;
+  language: string;
+  name: string;
+  default: boolean;
+}
+export interface ILiveStreamPlaylistMetadata {
+  VARIANT?: string;
+  MSEQ: number;
+  DSEQ: number;
+  TARGET_DUR: number;
+  START_ON: number;
+  END_ON: number;
+}
+export enum EnumStreamType {
+  "NONE" = 0,
+  "EVENT" = 1,
+  "LIVE" = 2,
+}
+
+/*
+Mock Live HLS M3U8 Maker
+  o     _______________________________
+ /\_  _|          |                   |
+_\__`[____________|___________________| 
+] [ \,      ][               ][
+------------------------------------------------
+*/
+export class MockLiveM3U8Generator {
+  header: string;
+  multiVariantM3u8: string;
+  //eventStreamData: ILiveStreamPlaylistMetadata | null;
+  liveStreamData: { [key: string]: ILiveStreamPlaylistMetadata } | any;
+  targetSegment: number;
+  replacementString: string;
+
+  constructor() {
+    this.header = `#EXTM3U
+#EXT-X-VERSION:7`;
+    this.multiVariantM3u8 = "<Not Set>";
+    this.targetSegment = -1;
+    this.replacementString = "";
+    this.liveStreamData = {};
+  }
+
+  shiftSegments(variant: string, num: number) {
+    if (this.liveStreamData) {
+      this.liveStreamData[variant].START_ON += num;
+      this.liveStreamData[variant].MSEQ += num;
+    }
+  }
+
+  pushSegments(variant: string, num: number) {
+    if (this.liveStreamData) {
+      this.liveStreamData[variant].END_ON += num;
+    }
+  }
+
+  setInitPlaylistData(initData: any) {
+    if (this.liveStreamData && Object.keys(this.liveStreamData).length > 0) {
+      Object.keys(this.liveStreamData).forEach((variant) => {
+        if (this.liveStreamData && this.liveStreamData[variant]) {
+          this.liveStreamData[variant] = JSON.parse(JSON.stringify(initData));
+        }
+      });
+    }
+  }
+
+  insertAt(data: string, segIdx: number) {
+    this.targetSegment = segIdx;
+    this.replacementString = data;
+  }
+
+  getMediaPlaylistM3U8(type: EnumStreamType, variant: string, useKey?: boolean, useMap?: boolean) {
+    let data: ILiveStreamPlaylistMetadata;
+    if (!this.liveStreamData) {
+      return "Error";
+    }
+    data = this.liveStreamData[variant];
+    let manifest = "";
+    manifest += this.header;
+    if (type === EnumStreamType.EVENT) {
+      manifest += `\n#EXT-X-PLAYLIST-TYPE:EVENT`;
+    }
+    manifest += `\n#EXT-X-TARGETDURATION:${data.TARGET_DUR}`;
+    manifest += `\n#EXT-X-DISCONTINUITY-SEQUENCE:${data.DSEQ}`;
+    manifest += `\n#EXT-X-MEDIA-SEQUENCE:${data.MSEQ}`;
+
+    if (useMap) {
+      manifest += `\n#EXT-X-MAP:URI="mock-init.mp4"`;
+    }
+    if (useKey) {
+      manifest += `\n#EXT-X-KEY:METHOD=AES-128,URI="mock-key.bin"`;
+    }
+
+    for (let i = data.START_ON; i < data.END_ON; i++) {
+      if (this.targetSegment === i) {
+        manifest += this.replacementString;
+        break;
+      }
+      manifest += `\n#EXTINF:${data.TARGET_DUR}`;
+      if (useMap) {
+        manifest += `\n${variant}-seg_${i}.m4s`;
+      } else {
+        manifest += `\n${variant}-seg_${i}.ts`;
+      }
+    }
+
+    return manifest;
+  }
+
+  setMultiVariant(opts: IMultiVariantOptions): void {
+    let manifest = "";
+    manifest += this.header;
+
+    // Add possible Audio Tracks
+    if (opts.audioTracks) {
+      manifest += "\n";
+      opts.audioTracks.forEach((track) => {
+        manifest += `\n#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="${track.groupId}",LANGUAGE="${
+          track.language
+        }",NAME="${track.name}",CHANNELS="2",DEFAULT=${
+          track.default ? "YES" : "NO"
+        },AUTOSELECT=YES,URI="audio-${track.groupId}_${track.language}.m3u8"`;
+
+        if (
+          this.liveStreamData &&
+          !this.liveStreamData[`audio-${track.groupId}_${track.language}`]
+        ) {
+          this.liveStreamData[`audio-${track.groupId}_${track.language}`] = {
+            MSEQ: 0,
+            DSEQ: 0,
+            TARGET_DUR: 10,
+            START_ON: 0,
+            END_ON: 6,
+          };
+        }
+      });
+    }
+    // Add possible Subtitle Tracks
+    if (opts.subtitleTracks) {
+      manifest += "\n";
+      opts.subtitleTracks.forEach((track) => {
+        manifest += `\n#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="${track.groupId}",LANGUAGE="${
+          track.language
+        }",NAME="${track.name}",FORCED=NO,DEFAULT=${
+          track.default ? "YES" : "NO"
+        },AUTOSELECT=YES,URI="sub-${track.groupId}_${track.language}.m3u8"`;
+
+        if (this.liveStreamData && !this.liveStreamData[`sub-${track.groupId}_${track.language}`]) {
+          this.liveStreamData[`sub-${track.groupId}_${track.language}`] = {
+            MSEQ: 0,
+            DSEQ: 0,
+            TARGET_DUR: 10,
+            START_ON: 0,
+            END_ON: 6,
+          };
+        }
+      });
+    }
+    // Add possible Media Tracks
+    manifest += "\n";
+    for (let i = 0; i < opts.videoTracks.length; i++) {
+      const vt = opts.videoTracks[i];
+      let variantStr = "\n#EXT-X-STREAM-INF:";
+      variantStr += `BANDWIDTH=${vt.bandwidth}`;
+      variantStr += `,RESOLUTION=${vt.width}x${vt.height}`;
+      variantStr += `,CODECS="${vt.codecs}"`;
+      if (vt.frameRate) {
+        variantStr += `,FRAME-RATE=${vt.frameRate}`;
+      }
+      if (vt.audio) {
+        variantStr += `,AUDIO="${vt.audio}"`;
+      }
+      if (vt.subtitle) {
+        variantStr += `,SUBTITLE="${vt.subtitle}"`;
+      }
+      // Add Variant URI
+      variantStr += `\nlevel_${i}.m3u8`;
+      manifest += variantStr;
+      // Lastly
+      if (this.liveStreamData && !this.liveStreamData[vt.bandwidth]) {
+        this.liveStreamData[`video-${vt.bandwidth}`] = {
+          MSEQ: 0,
+          DSEQ: 0,
+          TARGET_DUR: 10,
+          START_ON: 0,
+          END_ON: 6,
+        };
+      }
+    }
+
+    this.multiVariantM3u8 = manifest;
+  }
+
+  getMultiVariant(): string {
+    return this.multiVariantM3u8;
+  }
+}

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.ts"
+  ],
+  "helpers": [
+    "helpers/**/*.ts"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": true
+}


### PR DESCRIPTION
Planned to solve #14

~~Roughly half of the planned unit tests are implemented.~~

Most test cases have unit tests implemented for them. Not all, but many. A good start! 
To mock the HLSRecorder, the previously global helper function `timer(x: number): Promise<void>` needed to become a method if the HLSRecorder class, so that the Jasmine `spyOn()` methods could be used when mocking

Cases left are: 
- Fail cases
- Usage with Channel Engine cases

Furthermore, I think we should write unit tests for the Manifest Generators in a separate ticket/PR.