### PR TITLE
chore: add a function for adding restify server

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ const recorder = new HLSRecorder(engine, opts);
 recorder.on("mseq-increment", mseq => {
   // Do stuff with media seq
 });
+recorder.addServer(); // Create a Restify server instance in recorder
 
 recorder.listen(); // Have server listening on default port 8001
 

--- a/demo.ts
+++ b/demo.ts
@@ -47,6 +47,7 @@ recorder.on("error", (err: any) => {
 });
 
 const run = async () => {
+  recorder.addServer();
   recorder.start();
   recorder.listen(1377); // Playback at "http://localhost:1377/live/master.m3u8"
 };

--- a/index.ts
+++ b/index.ts
@@ -167,7 +167,7 @@ export class HLSRecorder extends EventEmitter {
 
   engine: any; // TODO: use channel engine type defs
   cookieJar: CookieJar;
-  serverStartTime: number;
+  serverStartTime: number | undefined;
   discontinuitySequence: any;
   serverStarted: boolean;
   shouldEmitt: boolean | null;
@@ -229,7 +229,13 @@ export class HLSRecorder extends EventEmitter {
       Options: opts,
     };
     debug(`Recorder Configs->: ${JSON.stringify(recorderConfigs, null, 2)}`);
+  }
 
+  // ----------------------
+  // -= Public functions =-
+  // ----------------------
+
+  addServer() {
     // Setup Server [!]
     this.server = restify.createServer();
     this.server.use(restify.plugins.queryParser());
@@ -282,9 +288,6 @@ export class HLSRecorder extends EventEmitter {
     });
   }
 
-  // ----------------------
-  // -= Public functions =-
-  // ----------------------
   listen(port: number) {
     this.server.listen(port, () => {
       debug(`${this.server.name} listening at ${this.server.url}`);


### PR DESCRIPTION
As a first step towards addressing the overhead issue mentioned in #35, this PR will have it so that a restify server is only instantiated when needed/called, instead of at the construction of an HLSRecorder