### PR TITLE
fix: passthrough source basic tags

### DIFF
--- a/spec/support/MockLiveM3U8Generator.ts
+++ b/spec/support/MockLiveM3U8Generator.ts
@@ -39,6 +39,8 @@ export interface IGetMediaPlaylistM3U8Options {
   mapString?: string;
 }
 export interface ISetInitPlaylistDataInput {
+  VERSION?: number; // hls version
+  INDEP_SEGS?: boolean; // add INDEPENDENT-SEGMENTS tag
   MSEQ: number; // starting media-sequence value
   DSEQ: number; // starting discontinuity-sequence value
   TARGET_DUR: number; // duration for each segment in playlist
@@ -132,11 +134,20 @@ export class MockLiveM3U8Generator {
     }
     data = this.liveStreamData[variant];
     let manifest = "";
-    manifest += this.header;
+    if (data.VERSION) {
+      manifest += `#EXTM3U
+      #EXT-X-VERSION:${data.VERSION}`;
+    } else {
+      manifest += this.header;
+    }
+
     if (type === EnumStreamType.EVENT) {
       manifest += `\n#EXT-X-PLAYLIST-TYPE:EVENT`;
     } else if (type === EnumStreamType.VOD) {
       manifest += `\n#EXT-X-PLAYLIST-TYPE:VOD`;
+    }
+    if (data.INDEP_SEGS) {
+      manifest += "\n#EXT-X-INDEPENDENT-SEGMENTS";
     }
     manifest += `\n#EXT-X-TARGETDURATION:${data.TARGET_DUR}`;
     manifest += `\n#EXT-X-DISCONTINUITY-SEQUENCE:${data.DSEQ}`;

--- a/util/handlers.ts
+++ b/util/handlers.ts
@@ -1,11 +1,7 @@
 import Debug from "debug";
 const debug = Debug("hls-recorder");
 import { ISegments } from "..";
-import {
-  GenerateMediaM3U8,
-  GenerateAudioM3U8,
-  GenerateSubtitleM3U8,
-} from "./manifest_generator";
+import { GenerateMediaM3U8, GenerateAudioM3U8, GenerateSubtitleM3U8 } from "./manifest_generator";
 
 export interface IRecData {
   mseq: number;
@@ -13,14 +9,11 @@ export interface IRecData {
   targetDuration: number;
   allSegments: ISegments;
   playlistType?: number;
+  version?: number;
+  independentSegments?: boolean;
 }
 
-export async function _handleMasterManifest(
-  req: any,
-  res: any,
-  next: any,
-  masterM3u: string
-) {
+export async function _handleMasterManifest(req: any, res: any, next: any, masterM3u: string) {
   try {
     if (masterM3u === "") {
       masterM3u = "Source HLS steam does not have a multivariant manifest";
@@ -36,12 +29,7 @@ export async function _handleMasterManifest(
   }
 }
 
-export async function _handleMediaManifest(
-  req: any,
-  res: any,
-  next: any,
-  recData: IRecData
-) {
+export async function _handleMediaManifest(req: any, res: any, next: any, recData: IRecData) {
   debug(`req.url=${req.url}`);
   try {
     let body = null;
@@ -59,12 +47,7 @@ export async function _handleMediaManifest(
   }
 }
 
-export async function _handleAudioManifest(
-  req: any,
-  res: any,
-  next: any,
-  recData: IRecData
-) {
+export async function _handleAudioManifest(req: any, res: any, next: any, recData: IRecData) {
   debug(`req.url=${req.url}`);
   try {
     let body = null;
@@ -82,12 +65,7 @@ export async function _handleAudioManifest(
   }
 }
 
-export async function _handleSubtitleManifest(
-  req: any,
-  res: any,
-  next: any,
-  recData: IRecData
-) {
+export async function _handleSubtitleManifest(req: any, res: any, next: any, recData: IRecData) {
   debug(`req.url=${req.url}`);
   try {
     let body = null;

--- a/util/manifest_generator.ts
+++ b/util/manifest_generator.ts
@@ -141,14 +141,16 @@ export async function GenerateMediaM3U8(BW: number, OPTIONS: IRecData): Promise<
   debug(`[m3u8generator]: Started Generating the Manifest with Mseq:[${OPTIONS.mseq}]...`);
 
   let m3u8 = "#EXTM3U\n";
-  m3u8 += "#EXT-X-VERSION:7\n";
+  m3u8 += `#EXT-X-VERSION:${OPTIONS.version ? OPTIONS.version : "6"}\n`;
   m3u8 += m3u8Header();
   if (OPTIONS.playlistType === PlaylistType.VOD) {
     m3u8 += `#EXT-X-PLAYLIST-TYPE:VOD\n`;
   } else {
     m3u8 += `#EXT-X-PLAYLIST-TYPE:EVENT\n`;
   }
-  m3u8 += "#EXT-X-INDEPENDENT-SEGMENTS\n";
+  if (OPTIONS.independentSegments) {
+    m3u8 += "#EXT-X-INDEPENDENT-SEGMENTS\n";
+  }
   m3u8 += "#EXT-X-TARGETDURATION:" + OPTIONS.targetDuration + "\n";
   m3u8 += "#EXT-X-MEDIA-SEQUENCE:" + OPTIONS.mseq + "\n";
   if (OPTIONS.dseq !== undefined) {
@@ -204,14 +206,16 @@ export async function GenerateAudioM3U8(
   debug(`[m3u8generator]: Started Generating the Audio Manifest with Mseq:[${OPTIONS.mseq}]...`);
 
   let m3u8 = "#EXTM3U\n";
-  m3u8 += "#EXT-X-VERSION:7\n";
+  m3u8 += `#EXT-X-VERSION:${OPTIONS.version ? OPTIONS.version : "6"}\n`;
   m3u8 += m3u8Header();
   if (OPTIONS.playlistType === PlaylistType.VOD) {
     m3u8 += `#EXT-X-PLAYLIST-TYPE:VOD\n`;
   } else {
     m3u8 += `#EXT-X-PLAYLIST-TYPE:EVENT\n`;
   }
-  m3u8 += "#EXT-X-INDEPENDENT-SEGMENTS\n";
+  if (OPTIONS.independentSegments) {
+    m3u8 += "#EXT-X-INDEPENDENT-SEGMENTS\n";
+  }
   m3u8 += "#EXT-X-TARGETDURATION:" + OPTIONS.targetDuration + "\n";
   m3u8 += "#EXT-X-MEDIA-SEQUENCE:" + OPTIONS.mseq + "\n";
   if (OPTIONS.dseq !== undefined) {
@@ -268,14 +272,16 @@ export async function GenerateSubtitleM3U8(
   debug(`[m3u8generator]: Started Generating the Subtitle Manifest with Mseq:[${OPTIONS.mseq}]...`);
 
   let m3u8 = "#EXTM3U\n";
-  m3u8 += "#EXT-X-VERSION:7\n";
+  m3u8 += `#EXT-X-VERSION:${OPTIONS.version ? OPTIONS.version : "6"}\n`;
   m3u8 += m3u8Header();
   if (OPTIONS.playlistType === PlaylistType.VOD) {
     m3u8 += `#EXT-X-PLAYLIST-TYPE:VOD\n`;
   } else {
     m3u8 += `#EXT-X-PLAYLIST-TYPE:EVENT\n`;
   }
-  m3u8 += "#EXT-X-INDEPENDENT-SEGMENTS\n";
+  if (OPTIONS.independentSegments) {
+    m3u8 += "#EXT-X-INDEPENDENT-SEGMENTS\n";
+  }
   m3u8 += "#EXT-X-TARGETDURATION:" + OPTIONS.targetDuration + "\n";
   m3u8 += "#EXT-X-MEDIA-SEQUENCE:" + OPTIONS.mseq + "\n";
   if (OPTIONS.dseq !== undefined) {
@@ -298,7 +304,10 @@ export async function GenerateMasterM3U8(m3u: any): Promise<string | null> {
   );
 
   let m3u8 = "#EXTM3U\n";
-  m3u8 += "#EXT-X-VERSION:7\n";
+  m3u8 += `#EXT-X-VERSION:${m3u.get("version") ? m3u.get("version") : "6"}\n`;
+  if (m3u.get("independentSegments")) {
+    m3u8 += "#EXT-X-INDEPENDENT-SEGMENTS\n";
+  }
   m3u8 += m3u8Header();
   m3u8 += `\n## Media Tracks \n`;
   for (let i = 0; i < m3u.items.StreamItem.length; i++) {


### PR DESCRIPTION
This PR fixes #41 

Manifest Generators will now set EXT-X-VERSION equal to that found in the source stream. Also the EXT-X-INDEPENDENT-SEGMENTS tag is only set if the source stream includes it.

Added updated unit test for this.

In the future we might need to extend beyond version and independent-segments tag.